### PR TITLE
feat: Toggle to show/hide images in recipe directions

### DIFF
--- a/dist/blocks.editor.build.css
+++ b/dist/blocks.editor.build.css
@@ -1,6 +1,2260 @@
-:root{--wp-admin-theme-color: #007cba;--wp-admin-theme-color-darker-10: #006ba1;--wp-admin-theme-color-darker-20: #005a87}html[amp] *,html[amp] *:before,html[amp] *:after{-webkit-box-sizing:border-box;box-sizing:border-box}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link{display:none}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit{right:20px}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit{margin-right:0}.wp-block-wpzoom-recipe-card-block-details p.help,.wp-block-wpzoom-recipe-card-block-details p.description{font-size:13px !important;opacity:0.7;width:100%;clear:both;float:left;margin-top:0;margin:10px 0}.wp-block-wpzoom-recipe-card-block-details p.help+p.help,.wp-block-wpzoom-recipe-card-block-details p.description+p.description{margin-top:0}.wp-block-wpzoom-recipe-card-block-details .placeholder{opacity:.5;pointer-events:none}.wp-block-wpzoom-recipe-card-block-details .details-title{float:none}.wp-block-wpzoom-recipe-card-block-details .detail-buttons{clear:both;width:100%;text-align:center}.wp-block-wpzoom-recipe-card-block-details .detail-item-controls-container{display:none;position:absolute;top:0px;left:-52px;padding:2px;background-color:#fff;z-index:10;border:1px solid #e2e4e7}.wp-block-wpzoom-recipe-card-block-details .detail-item-controls-container .detail-item-button{display:block}.wp-block-wpzoom-recipe-card-block-details .detail-item:focus-within .detail-item-controls-container{display:block}.wp-block-wpzoom-recipe-card-block-details .detail-item .detail-item-value{padding:0;text-align:left}.wp-block-wpzoom-recipe-card-block-details .components-icon-button .dashicon+.components-icon-button-text{margin-left:5px}.wpzoom-recipe-card-modal-form .form-group{margin-left:-10px;margin-right:-10px}.wpzoom-recipe-card-modal-form .form-group::after{content:'';clear:both;display:table}.wpzoom-recipe-card-modal-form .form-group>.components-base-control{float:left;width:50%;padding-left:10px;padding-right:10px;margin-bottom:0}.wpzoom-recipe-card-modal-form .form-group>.components-base-control .components-base-control__label{display:block}.wpzoom-recipe-card-modal-form .modal-icons_kit-tab-panel .components-button{background:transparent;border:none;-webkit-box-shadow:none;box-shadow:none;cursor:pointer;padding:3px 15px;margin-left:0;font-weight:400;color:#191e23;outline-offset:-1px;-webkit-transition:-webkit-box-shadow .1s linear;transition:-webkit-box-shadow .1s linear;-o-transition:box-shadow .1s linear;transition:box-shadow .1s linear;transition:box-shadow .1s linear, -webkit-box-shadow .1s linear;height:40px}.wpzoom-recipe-card-modal-form .modal-icons_kit-tab-panel .components-button.active-tab{-webkit-box-shadow:inset 0 -3px #007cba;box-shadow:inset 0 -3px #007cba;font-weight:600;position:relative}.wpzoom-recipe-card-icon_kit{padding:15px 0;margin-top:10px;border-top:1px solid #ededed}.wpzoom-recipe-card-icon_kit::after{content:'';clear:both;display:table}.wpzoom-recipe-card-icon_kit .wpzoom-recipe-card-icons__single-element{float:left;width:8%;padding:5px;margin:1%;height:40px;line-height:30px;text-align:center;background-color:#f0f0f0;border-radius:2px;cursor:pointer}.wpzoom-recipe-card-icon_kit .wpzoom-recipe-card-icons__single-element::before{margin:0;font-size:20px}.wpzoom-recipe-card-icon_kit .wpzoom-recipe-card-icons__single-element:hover{-webkit-box-shadow:inset 0 0 0 1px #e2e4e7,inset 0 0 0 2px #fff,0 1px 1px rgba(25,30,35,0.2);box-shadow:inset 0 0 0 1px #e2e4e7,inset 0 0 0 2px #fff,0 1px 1px rgba(25,30,35,0.2);background-color:#fff;color:#191e23}.wpzoom-recipe-card-icon_kit .wpzoom-recipe-card-icons__single-element.icon-element-active{-webkit-box-shadow:inset 0 0 0 1px #007cba, inset 0 0 0 2px #fff;box-shadow:inset 0 0 0 1px #007cba, inset 0 0 0 2px #fff;background-color:#007cba;color:#ffffff}#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-details .detail-item-label{font-weight:bold;margin-top:0;margin-bottom:0}#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-details p{margin-top:0;margin-bottom:0}#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-details ul,#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-details ol{margin:0;padding:0}
-:root{--wp-admin-theme-color: #007cba;--wp-admin-theme-color-darker-10: #006ba1;--wp-admin-theme-color-darker-20: #005a87}html[amp] *,html[amp] *:before,html[amp] *:after{-webkit-box-sizing:border-box;box-sizing:border-box}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link{display:none}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit{right:20px}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit{margin-right:0}.wp-block-wpzoom-recipe-card-block-directions p.help,.wp-block-wpzoom-recipe-card-block-directions p.description{font-size:13px !important;margin-top:0;opacity:0.7}.wp-block-wpzoom-recipe-card-block-directions .wpzoom-recipe-card-print-link{right:0}.wp-block-wpzoom-recipe-card-block-directions .direction-step{position:relative;margin:4px 0;padding:10px 4px 10px;border:1px solid #d3d3d3;list-style-type:none;display:-ms-flexbox;display:flex}.wp-block-wpzoom-recipe-card-block-directions .direction-step .direction-step-group-title{font-weight:bold}.wp-block-wpzoom-recipe-card-block-directions .direction-step .editor-rich-text,.wp-block-wpzoom-recipe-card-block-directions .direction-step .block-editor-rich-text__editable{display:inline-block;width:93%}.wp-block-wpzoom-recipe-card-block-directions .directions-list>li::before{text-align:center}.wp-block-wpzoom-recipe-card-block-directions .direction-step-button-container{display:none;text-align:right}.wp-block-wpzoom-recipe-card-block-directions .direction-step-button-container button{display:-ms-inline-flexbox;display:inline-flex}.wp-block-wpzoom-recipe-card-block-directions .direction-buttons{text-align:center}.wp-block-wpzoom-recipe-card-block-directions .direction-buttons button{display:-ms-inline-flexbox;display:inline-flex}.wp-block-wpzoom-recipe-card-block-directions .direction-buttons button.components-icon-button:not(:disabled):not([aria-disabled=true]):not(.is-default):hover,.wp-block-wpzoom-recipe-card-block-directions .direction-step-button-container button.components-icon-button:not(:disabled):not([aria-disabled=true]):not(.is-default):hover{color:#007cba;-webkit-box-shadow:none;box-shadow:none}.wp-block-wpzoom-recipe-card-block-directions .direction-step-button-container button.direction-step-button-delete:not(:disabled):not([aria-disabled=true]):not(.is-default):hover{color:#a00}.wp-block-wpzoom-recipe-card-block-directions .components-icon-button .dashicon+.components-icon-button-text{margin-left:5px}.wp-block-wpzoom-recipe-card-block-directions .direction-step:focus{outline:none}.wp-block-wpzoom-recipe-card-block-directions .direction-step:focus-within .direction-step-button-container{display:-ms-flexbox;display:flex}#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-directions .wpzoom-recipe-card-print-link a{color:#a0a0a0}#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-directions p{margin-top:0;margin-bottom:0}#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-directions ul,#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-directions ol{margin:0;padding:0}
-:root{--wp-admin-theme-color: #007cba;--wp-admin-theme-color-darker-10: #006ba1;--wp-admin-theme-color-darker-20: #005a87}html[amp] *,html[amp] *:before,html[amp] *:after{-webkit-box-sizing:border-box;box-sizing:border-box}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link{display:none}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit{right:20px}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit{margin-right:0}.wp-block-wpzoom-recipe-card-block-ingredients p.help,.wp-block-wpzoom-recipe-card-block-ingredients p.description{font-size:13px !important;margin-top:0;opacity:0.7}.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item{position:relative;list-style-type:none;display:-ms-flexbox;display:flex}.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item .editor-rich-text,.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item .block-editor-rich-text__editable{display:inline-block;width:93%}.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item .ingredient-item-group-title{font-weight:bold}.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item:before{display:none !important}.wp-block-wpzoom-recipe-card-block-ingredients .ingredients-list>li{cursor:text !important}.wp-block-wpzoom-recipe-card-block-ingredients .ingredients-list>li .ingredient-item-name:hover{text-decoration:none !important}.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item-button-container{display:none;text-align:right}.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item-button-container button{display:-ms-inline-flexbox;display:inline-flex}.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-buttons{text-align:center}.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-buttons button{display:-ms-inline-flexbox;display:inline-flex}.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-buttons button.components-icon-button:not(:disabled):not([aria-disabled=true]):not(.is-default):hover,.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item-button-container button.components-icon-button:not(:disabled):not([aria-disabled=true]):not(.is-default):hover{color:#191e23;-webkit-box-shadow:none;box-shadow:none}.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item-button-container button.ingredient-item-button-delete:not(:disabled):not([aria-disabled=true]):not(.is-default):hover{color:#a00}.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item-button-container button.components-icon-button:not(:disabled):not([aria-disabled=true]):not(.is-default):hover,.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-buttons .components-icon-button:not(:disabled):not([aria-disabled=true]):not(.is-default):hover{background-color:#ece8c8}.wp-block-wpzoom-recipe-card-block-ingredients .components-icon-button .dashicon+.components-icon-button-text{margin-left:5px}.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item:focus{outline:none}.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item:focus-within .ingredient-item-button-container{display:-ms-flexbox;display:flex}#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-ingredients .wpzoom-recipe-card-print-link a{color:#a0a0a0}#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-ingredients p{margin-bottom:0}#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-ingredients ul,#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-ingredients ol{margin:0;padding:0}
-:root{--wp-admin-theme-color: #007cba;--wp-admin-theme-color-darker-10: #006ba1;--wp-admin-theme-color-darker-20: #005a87}html[amp] *,html[amp] *:before,html[amp] *:after{-webkit-box-sizing:border-box;box-sizing:border-box}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link{display:none}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit{right:20px}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit{margin-right:0}.wp-block-wpzoom-recipe-card-block-recipe-card{position:relative}.wp-block-wpzoom-recipe-card-block-recipe-card.is-loading-block>*:not(.wpzoom-recipe-card-loading-spinner){display:none}.wp-block-wpzoom-recipe-card-block-recipe-card .components-placeholder.recipe-card-image-placeholder{margin-top:20px;margin-bottom:10px}.wp-block-wpzoom-recipe-card-block-recipe-card.recipe-card-noimage .components-placeholder.recipe-card-image-placeholder{display:none}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image-placeholder,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image-preview{margin-top:0;margin-bottom:0;float:left;width:40%;text-align:left}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image-preview .recipe-card-image{width:100%;float:none}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.header-content-align-right .recipe-card-image-preview .recipe-card-image{width:100%;float:none}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.header-content-align-right .recipe-card-image-placeholder,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.header-content-align-right .recipe-card-image-preview{float:right}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details{margin-bottom:0}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .details-items .detail-item>.detail-item-icon{display:block}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .details-items .detail-item>div:nth-child(2){display:block}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .details-items .detail-item>div:nth-child(3),.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .details-items .detail-item div:nth-child(4){display:inline-block}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .details-items .detail-item .detail-item-value,.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .details-items .detail-item .detail-item-unit{padding:0;margin-top:0;text-align:left}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .details-items .detail-item .components-base-control{display:inline-block;margin-right:5px}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .details-items .detail-item .components-base-control .components-base-control__field{margin-bottom:0}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .details-items .detail-item .components-base-control .components-base-control__field .components-text-control__input{width:50px;font-size:12px;padding:3px 5px;min-height:auto;height:26px}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details+p.description{margin-bottom:10px !important}.wp-block-wpzoom-recipe-card-block-recipe-card .ingredient-item{position:relative;list-style-type:none;display:-ms-flexbox;display:flex}.wp-block-wpzoom-recipe-card-block-recipe-card .ingredient-item .block-editor-rich-text__editable{display:inline-block;width:75%}.wp-block-wpzoom-recipe-card-block-recipe-card .ingredient-item .ingredient-item-group-title{font-weight:bold}.wp-block-wpzoom-recipe-card-block-recipe-card .ingredients-list>li .ingredient-item-name{padding-left:0 !important}.wp-block-wpzoom-recipe-card-block-recipe-card .ingredients-list>li .ingredient-item-name:hover{text-decoration:none !important}.wp-block-wpzoom-recipe-card-block-recipe-card .ingredients-list>li .tick-circle{cursor:default !important;display:none !important}.wp-block-wpzoom-recipe-card-block-recipe-card.block-alignment-right .ingredients-list>li .ingredient-item-name{padding-right:0 !important}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list.layout-2-columns{-webkit-columns:1 !important;-moz-columns:1 !important;columns:1 !important}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .ingredients-list>li,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list>li,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .ingredients-list>li{cursor:text !important}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-summary,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-summary,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-summary{margin-top:0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .ingredients-list>li{padding:0 !important;min-height:37px}.wp-block-wpzoom-recipe-card-block-recipe-card .ingredient-item-button-container{display:none;text-align:right}.wp-block-wpzoom-recipe-card-block-recipe-card .ingredient-item-button-container button{display:-ms-inline-flexbox;display:inline-flex;padding:2px !important;min-width:30px !important;height:30px}.wp-block-wpzoom-recipe-card-block-recipe-card .ingredient-buttons{text-align:center}.wp-block-wpzoom-recipe-card-block-recipe-card .ingredient-buttons button{display:-ms-inline-flexbox;display:inline-flex}.wp-block-wpzoom-recipe-card-block-recipe-card .ingredient-item-button-container button.ingredient-item-button-delete:not(:disabled):not([aria-disabled=true]):not(.is-default):hover{color:#a00}.wp-block-wpzoom-recipe-card-block-recipe-card .ingredient-item:focus{outline:none}.wp-block-wpzoom-recipe-card-block-recipe-card .ingredient-item:focus-within .ingredient-item-button-container{display:-ms-flexbox;display:flex}.wp-block-wpzoom-recipe-card-block-recipe-card .directions-list>li::before{left:10px;top:6px}.wp-block-wpzoom-recipe-card-block-recipe-card .direction-step .direction-step-group-title{font-weight:bold}.wp-block-wpzoom-recipe-card-block-recipe-card .direction-step-button-container{display:none;text-align:right}.wp-block-wpzoom-recipe-card-block-recipe-card .direction-step-button-container button{display:-ms-inline-flexbox;display:inline-flex}.wp-block-wpzoom-recipe-card-block-recipe-card .direction-buttons{text-align:center}.wp-block-wpzoom-recipe-card-block-recipe-card .direction-buttons button{display:-ms-inline-flexbox;display:inline-flex}.wp-block-wpzoom-recipe-card-block-recipe-card .direction-step-button-container button.direction-step-button-delete:not(:disabled):not([aria-disabled=true]):not(.is-default):hover{color:#a00}.wp-block-wpzoom-recipe-card-block-recipe-card .direction-step:focus{outline:none}.wp-block-wpzoom-recipe-card-block-recipe-card .direction-step:focus-within .direction-step-button-container{display:block}.wp-block-wpzoom-recipe-card-block-recipe-card p.help,.wp-block-wpzoom-recipe-card-block-recipe-card p.description{font-size:13px;opacity:0.7;margin-top:0;margin-bottom:10px}.wp-block-wpzoom-recipe-card-block-recipe-card .components-icon-button .dashicon+.components-icon-button-text{margin-left:5px}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-video .components-placeholder__instructions{display:block}.wpzoom-recipe-card-video-settings .editor-video__recipe-card .components-button+.components-button{margin-top:1em;margin-right:8px}.wpzoom-recipe-card-video-settings .editor-video__url-input-container{position:relative;width:100%;margin-bottom:10px}.wpzoom-recipe-card-settings .components-base-control__label,.wpzoom-recipe-card-seo-settings .components-base-control__label,.wpzoom-recipe-card-details .components-base-control__label,.wpzoom-recipe-card-structured-data-testing .components-base-control__label{font-weight:500}.wpzoom-recipe-card-settings .components-base-control__label+.components-toggle-control,.wpzoom-recipe-card-seo-settings .components-base-control__label+.components-toggle-control,.wpzoom-recipe-card-details .components-base-control__label+.components-toggle-control,.wpzoom-recipe-card-structured-data-testing .components-base-control__label+.components-toggle-control{margin-top:1em;margin-bottom:1em}.wpzoom-recipe-card-details .components-panel__row{display:block;margin-top:0;margin-bottom:15px;padding-bottom:15px;border-bottom:1px solid #e2e4e7}.wpzoom-recipe-card-details .components-panel__row:last-child{border:none;margin:0;padding:0}.wpzoom-recipe-card-details .components-panel__row .components-base-control:nth-child(1){width:100%;clear:both;margin-bottom:10px !important}.wpzoom-recipe-card-details .components-panel__row .components-base-control:nth-child(2){padding-right:5px}.wpzoom-recipe-card-details .components-panel__row .components-base-control:nth-child(3){padding-left:5px}.wpzoom-recipe-card-details .components-panel__row .components-base-control:nth-child(2),.wpzoom-recipe-card-details .components-panel__row .components-base-control:nth-child(3){width:50%;display:inline-block}.wpzoom-recipe-card-details .components-panel__row .components-base-control{margin-bottom:0}.wpzoom-recipe-card-details .components-panel__row .components-base-control .components-base-control__field{margin-bottom:0}.wpzoom-recipe-card-details .components-panel__row .components-base-control .components-base-control__label{max-width:90%;font-weight:500}.wpzoom-recipe-card-details .components-panel__row .components-base-control:last-child{margin-bottom:0 !important}.wpzoom-recipe-card-details .components-panel__row .editor-calculate-total-time{margin-top:10px;margin-bottom:5px}.wpzoom-recipe-card-details .components-base-control.components-toggle-control{margin-bottom:10px}.wpzoom-recipe-card-details .components-notice{margin:5px 0}.wpzoom-recipe-card-details .components-notice .components-notice__content{margin-right:0}.wpzoom-recipe-card-details .components-notice .components-notice__content p:last-child{margin-bottom:0}.wpzoom-recipe-card-details .components-notice.is-dismissible{padding:8px}.wpzoom-recipe-card-custom-details .components-panel__row{display:block;margin-top:0;margin-bottom:15px;padding-bottom:15px;border-bottom:1px solid #e2e4e7}.wpzoom-recipe-card-custom-details .components-panel__row:last-child{border:none;margin:0;padding:0}.wpzoom-recipe-card-custom-details .components-panel__row .components-base-control:nth-child(1){width:100%;clear:both;margin-bottom:10px !important}.wpzoom-recipe-card-custom-details .components-panel__row .components-base-control:nth-child(2){padding-right:5px}.wpzoom-recipe-card-custom-details .components-panel__row .components-base-control:nth-child(3){padding-left:5px}.wpzoom-recipe-card-custom-details .components-panel__row .components-base-control:nth-child(2),.wpzoom-recipe-card-custom-details .components-panel__row .components-base-control:nth-child(3){width:50%;display:inline-block}.wpzoom-recipe-card-custom-details .components-panel__row .components-base-control{margin-bottom:0}.wpzoom-recipe-card-custom-details .components-panel__row .components-base-control .components-base-control__field{margin-bottom:0}.wpzoom-recipe-card-custom-details .components-panel__row .components-base-control .components-base-control__label{max-width:90%;font-weight:500}.wpzoom-recipe-card-custom-details .components-panel__row .components-base-control:last-child{margin-bottom:0 !important}.wpzoom-recipe-card-custom-details .components-panel__row .components-base-control.components-toggle-control{margin-top:20px}.wpzoom-recipe-card-custom-details .components-panel__row .components-base-control.components-toggle-control .components-base-control__help{margin-top:10px}.wpzoom-recipe-card-settings .components-base-control__help,.wpzoom-recipe-card-seo-settings .components-base-control__help,.wpzoom-recipe-card-details .components-base-control__help,.wpzoom-recipe-card-structured-data-testing .components-base-control__help{margin-top:0}.wpzoom-recipe-card-seo-settings .components-panel__row .components-base-control,.wpzoom-recipe-card-details .components-panel__row .components-base-control{margin-bottom:0}.wpzoom-recipe-card-seo-settings .components-panel__row .components-base-control+span,.wpzoom-recipe-card-details .components-panel__row .components-base-control+span{margin-top:1.25em}.wpzoom-recipe-card-structured-data-testing .text-color-red{color:#ff2725}.wpzoom-recipe-card-structured-data-testing .text-color-orange{color:#ef6c00}.wpzoom-recipe-card-structured-data-testing .text-color-green{color:#29a740}.wpzoom-recipe-card-structured-data-testing .components-panel__row strong{width:60%;word-break:break-word}.wpzoom-recipe-card-structured-data-testing .components-notice{margin:5px 0}.wpzoom-recipe-card-structured-data-testing .components-notice .components-notice__content p:last-child{margin-bottom:0}#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-recipe-card .detail-item-label{font-weight:bold}#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-recipe-card p:not(.description){margin-top:0;margin-bottom:0}#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-recipe-card ul,#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-recipe-card ol{margin:0;padding:0}.wpzoom-recipe-card-extra-options .form-group{margin-bottom:15px;padding-bottom:15px;border-bottom:1px solid #ededed}.wpzoom-recipe-card-extra-options .form-group:last-child{border-bottom:0;text-align:right}.wpzoom-recipe-card-extra-options .form-group .wrap-label{margin-bottom:15px;padding-bottom:15px;border-bottom:1px solid #ededed}.wpzoom-recipe-card-extra-options .form-group .wrap-label label{font-size:18px;font-weight:500;line-height:1.4em;margin-bottom:5px;display:block}.wpzoom-recipe-card-extra-options .form-group .wrap-label .description{margin-top:0;margin-bottom:0}.wpzoom-recipe-card-extra-options .form-group .wrap-content .bulk-add-unordered-list,.wpzoom-recipe-card-extra-options .form-group .wrap-content .bulk-add-ordered-list{padding:10px;border:1px solid #acacac;border-radius:3px;height:150px;overflow-x:scroll}.wpzoom-recipe-card-extra-options .form-group .wrap-content .bulk-add-unordered-list{margin-bottom:15px}.wpzoom-recipe-card-extra-options .form-group .wrap-content .bulk-add-unordered-list li{list-style-type:disc;margin-left:20px}.wpzoom-recipe-card-extra-options .form-group .wrap-content .bulk-add-ordered-list li{list-style-type:decimal;margin-left:20px}.wpzoom-recipe-card-extra-options .form-group button{margin-right:10px}.wpzoom-recipe-card-extra-options .form-group button:last-child{margin-right:0}.wpzoom-recipe-card-extra-options .bulk-add-enter-ingredients label,.wpzoom-recipe-card-extra-options .bulk-add-enter-directions label{font-size:14px;font-weight:bold}.wpzoom-recipe-card-extra-options .bulk-add-warning-alert,.wpzoom-recipe-card-extra-options .bulk-add-danger-alert{font-style:normal;background:#ffe9e9;padding:10px;border-radius:5px;border:1px solid #ff9090;color:#c00000}.wpzoom-recipe-card-extra-options .bulk-add-warning-alert{background:#fef5da;border-color:#fac937;color:#a87f04}.components-toolbar button.wpzoom-recipe-card__extra-options{color:#fff !important}.components-toolbar button.wpzoom-recipe-card__extra-options.is-large{margin:0 5px}.components-toolbar button.wpzoom-recipe-card__extra-options.components-icon-button.is-primary:hover{background:#007eb1;border-color:#00435d;color:#fff !important;-webkit-box-shadow:inset 0 -1px 0 #00435d;box-shadow:inset 0 -1px 0 #00435d}.components-button svg[size="24"]{width:24px;height:24px}.wpzoom-recipe-card-settings .components-button.editor-post-featured-image__preview{padding:0;margin:0;border:none;outline:none;height:100%;line-height:0}.wpzoom-recipe-card-settings .components-button-group{display:block}.wpzoom-recipe-card-styles .components-panel__body-toggle.components-button,.wpzoom-recipe-card-color-scheme .components-panel__body-toggle.components-button,.wpzoom-recipe-card-settings .components-panel__body-toggle.components-button,.wpzoom-recipe-card-video-settings .components-panel__body-toggle.components-button,.wpzoom-recipe-card-food-labels .components-panel__body-toggle.components-button,.wpzoom-recipe-card-seo-settings .components-panel__body-toggle.components-button,.wpzoom-recipe-card-details .components-panel__body-toggle.components-button,.wpzoom-recipe-card-custom-details .components-panel__body-toggle.components-button,.wpzoom-recipe-card-structured-data-testing .components-panel__body-toggle.components-button{display:-ms-flexbox;display:flex;-ms-flex-direction:row-reverse;flex-direction:row-reverse;-ms-flex-pack:end;justify-content:flex-end}.wpzoom-recipe-card-styles .components-panel__body-toggle svg.components-panel__icon,.wpzoom-recipe-card-color-scheme .components-panel__body-toggle svg.components-panel__icon,.wpzoom-recipe-card-settings .components-panel__body-toggle svg.components-panel__icon,.wpzoom-recipe-card-video-settings .components-panel__body-toggle svg.components-panel__icon,.wpzoom-recipe-card-food-labels .components-panel__body-toggle svg.components-panel__icon,.wpzoom-recipe-card-seo-settings .components-panel__body-toggle svg.components-panel__icon,.wpzoom-recipe-card-details .components-panel__body-toggle svg.components-panel__icon,.wpzoom-recipe-card-custom-details .components-panel__body-toggle svg.components-panel__icon,.wpzoom-recipe-card-structured-data-testing .components-panel__body-toggle svg.components-panel__icon{width:20px;height:20px;margin:0 10px 0 0;fill:#2ea55f}.ai-button{background-color:white;color:#E1581A;border:2px solid #E1581A;padding:14px 40px;cursor:pointer;-webkit-transition:background-color 0.3s, color 0.3s;-o-transition:background-color 0.3s, color 0.3s;transition:background-color 0.3s, color 0.3s;width:-webkit-fit-content;width:-moz-fit-content;width:fit-content;margin-left:auto !important;display:block;border-radius:5px;font-weight:600 !important;padding:15px 20px 35px 20px !important}.ai-button:hover{background-color:#E1581A;color:white !important}.ai-button:hover svg path{fill:white}.ai-button svg{margin-right:10px}.popup-overlay{position:fixed !important;top:0 !important;left:0 !important;background:#00000055;-webkit-transform:none !important;-ms-transform:none !important;transform:none !important;width:100%;height:100%;z-index:999}.popup-content{position:absolute;top:50%;left:50%;-webkit-transform:translate(-50%, -50%);-ms-transform:translate(-50%, -50%);transform:translate(-50%, -50%);background-color:#fff;padding:40px 60px;border:2px solid #F2F4F6;border-radius:10px;width:570px;-webkit-box-shadow:0 15px 25px 0 rgba(0,0,0,0.05);box-shadow:0 15px 25px 0 rgba(0,0,0,0.05)}.popup-content h2{font-size:18px;color:#041728;margin-top:35px;font-weight:600}.popup-content ul li{font-size:16px;line-height:1.4;font-weight:400;color:#E1581A}.popup-content input[type="text"]{font-size:20px;color:var(--rcb-dark, #041728);padding:10px 10px 10px 70px;border-radius:4px;margin:0 0 20px 0;border:1px solid #7C848A;width:440px;height:47px;border:1px solid var(--rcb-grey, #7C848A);background:var(--white, #fff)}.submit-button{font-size:22px;background-color:#f34b00 !important;color:#fff;border:none;border-radius:5px;cursor:pointer;display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center;-ms-flex-pack:center;justify-content:center;height:60px;font-weight:500;width:440px;padding:14px;justify-content:center;border-radius:5px;background:var(--main-color, #E1581A)}.submit-button:hover{background-color:#c03b00 !important}.submit-button span{display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center}.submit-button span svg{height:26px;width:26px;margin-right:16px}.manual-button{width:-webkit-fit-content;width:-moz-fit-content;width:fit-content;margin-left:auto !important;display:block;color:#7C848A;border:2px solid #7C848A;background-color:white;border-radius:5px;font-weight:500;font-size:14px !important}.components-button.ai-button{position:relative}.components-button.ai-button span.btn-svg{position:absolute;top:8px}.components-button.ai-button span.btn-text{padding-left:20px;font-size:15px;font-weight:500}.components-button.regenerate-recipe-button{padding:0 0 0 0;font-size:14px;font-weight:600}.components-button.regenerate-recipe-button span.btn-text{color:#E1581A;font-size:12px;font-weight:600}.components-button.regenerate-recipe-button span.btn-svg{margin:0 5px 0 0}.svg-input{position:relative}.svg-input span svg{position:absolute;top:14px;left:20px}.Content-suggestions{text-align:center}.Content-suggestions h4{color:#041728;font-size:15px;margin:25px 0 15px 0;opacity:1;text-align:left}.Content-suggestions ul{text-align:left}.Content-suggestions ul li{opacity:1;cursor:pointer}.page-loader{position:fixed;top:0;left:0;width:100%;height:100%;background-color:rgba(255,255,255,0.8);z-index:9999}@-webkit-keyframes spin{0%{-webkit-transform:translate(-50%, -50%) rotate(0deg);transform:translate(-50%, -50%) rotate(0deg)}100%{-webkit-transform:translate(-50%, -50%) rotate(360deg);transform:translate(-50%, -50%) rotate(360deg)}}@keyframes spin{0%{-webkit-transform:translate(-50%, -50%) rotate(0deg);transform:translate(-50%, -50%) rotate(0deg)}100%{-webkit-transform:translate(-50%, -50%) rotate(360deg);transform:translate(-50%, -50%) rotate(360deg)}}.wp-block-wpzoom-recipe-card-block-recipe-card.image-loader .recipe-card-image-placeholder,.wp-block-wpzoom-recipe-card-block-recipe-card.image-loader .recipe-card-image-preview,.loader{position:fixed;top:0;left:0;width:100%;height:100%;background-color:rgba(0,0,0,0.5);display:-ms-flexbox;display:flex;-ms-flex-pack:center;justify-content:center;-ms-flex-align:center;align-items:center;z-index:9999999}.wp-block-wpzoom-recipe-card-block-recipe-card.image-loader .recipe-card-image-placeholder,.wp-block-wpzoom-recipe-card-block-recipe-card.image-loader .recipe-card-image-preview{position:relative;min-height:200px;-webkit-box-shadow:none;box-shadow:none}.wp-block-wpzoom-recipe-card-block-recipe-card.image-loader .recipe-card-image-placeholder div,.wp-block-wpzoom-recipe-card-block-recipe-card.image-loader .recipe-card-image-preview div{display:none}.recipe-image-placeholder-wrapper .loader{position:absolute}.wp-block-wpzoom-recipe-card-block-recipe-card.image-loader .recipe-card-image-placeholder::after,.wp-block-wpzoom-recipe-card-block-recipe-card.image-loader .recipe-card-image-preview::after,.loader::after{content:"";border:4px solid rgba(255,255,255,0.3);border-top:4px solid #E1581A;border-radius:50%;width:40px;height:40px;-webkit-animation:spin 1s linear infinite;animation:spin 1s linear infinite}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image-preview .recipe-card-image{margin:10px 0}@keyframes spin{0%{-webkit-transform:rotate(0deg);transform:rotate(0deg)}100%{-webkit-transform:rotate(360deg);transform:rotate(360deg)}}@keyframes spin{0%{-webkit-transform:rotate(0deg);transform:rotate(0deg)}100%{-webkit-transform:rotate(360deg);transform:rotate(360deg)}}#inspector-text-control-0:focus{border:1px solid var(--rcb-grey, #7C848A)}#inspector-text-control-0::-webkit-input-placeholder{color:#c4b8b8}#inspector-text-control-0::-moz-placeholder{color:#c4b8b8}#inspector-text-control-0::-ms-input-placeholder{color:#c4b8b8}#inspector-text-control-0::placeholder{color:#c4b8b8}.manual-button:active,.manual-button:hover{border-radius:5px;border:2px solid var(--rcb-grey, #7C848A);color:#7C848A}.components-button.ai-button span.btn-text{font-weight:600 !important;padding-left:28px}.components-button.ai-button span.btn-svg{top:15px}.use-recipe-image-prompt{margin:0 0 25px 0}.use-recipe-image-prompt .components-checkbox-control__input[type=checkbox]:checked,.use-recipe-image-prompt .components-checkbox-control__input[type=checkbox]:indeterminate{background-color:#E1581A;border-color:#E1581A}.wp-block .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-header-wrap{margin-top:20px !important}.wp-block .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image{margin-top:20px}.wp-block .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-mint .recipe-card-header-container{margin-top:20px !important}.wp-block .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-mint .ai-button{margin-right:auto !important;margin-left:0 !important}.wp-block .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-accent-color-header .recipe-card-header-container{margin-top:20px !important}.close-button{position:absolute;top:-10px;right:-10px;width:26px;height:26px;background-color:#f34b00;cursor:pointer;display:-ms-flexbox;display:flex;-ms-flex-pack:center;justify-content:center;-ms-flex-align:center;align-items:center;color:#ffffff;border-radius:20px;padding:0 4px 1px 5px;border:none}.close-button span{margin:1px 1px 0 0}.submit-button{opacity:1;-webkit-transition:opacity 0.3s ease;-o-transition:opacity 0.3s ease;transition:opacity 0.3s ease;cursor:pointer}.submit-button.disabled{opacity:0.5;cursor:not-allowed}.calculate-nutr{background-color:white;color:#E1581A;border:2px solid #E1581A;cursor:pointer;-o-transition:background-color 0.3s, color 0.3s;margin-left:auto !important;display:block;border-radius:5px;font-weight:600 !important;padding:10px 30px 30px 30px !important;margin-right:100px;font-size:15px}.popup-content-error{border-radius:6px !important;width:475px;padding:0}.popup-content-error h4{border-radius:0px !important;font-size:20px;text-align:center;line-height:1.5em}.popup-content-error .error-close-btn{background:white;color:#8080809e;right:20px;top:15px}.popup-content-error .error-close-btn span{font-size:30px !important}.popup-content-error .Content-suggestions p{text-align:center;font-size:14px}.popup-content-error .Content-suggestions{padding:50px 30px 30px}button.components-button.try-again,.components-button.buyMore,button.components-button.activate-license{margin:0 auto;display:block;background-color:#E1581A;color:#fff;width:100%;border-radius:3px;font-size:15px;height:40px;margin-top:80px}.popup-content-error a.try-again,.components-button.buyMore,.popup-content-error a.activate-license{margin:0 auto;display:block;background-color:#E1581A;color:#fff;width:100%;border-radius:3px;font-size:15px;height:40px;margin-top:20px;text-align:center;padding:10px}.components-button.buyMore:active{color:#fff}.components-button.buyMore:hover{background-color:#000 !important}.popup-content-error a.activate-license,button.components-button.activate-license{margin-top:0}.popup-content-error a.try-again span.btn-text,.popup-content-error a.activate-license span.btn-text{color:white;font-size:15px;text-align:center;margin:0 auto}.popup-svg{width:100px;display:block;margin:0 auto;background:#ffe7d4;border-radius:3px;padding:10px 10px 10px 10px}.popup-svg .error-svg{display:block;margin:0 auto}.popup-content-error .ai-credits-error{padding:35px 35px 30px !important}.popup-content-error a.ai-error{margin:0px !important}span.ai-error{width:100%;display:block;padding:30px 0px 30px 0px;margin-top:40px;text-align:center}span.ai-error a{text-align:center;color:#E1581A;font-size:15px;text-decoration:underline}p.ai-p{padding:0px 20px 0px 20px}@media only screen and (max-width: 640px){.popup-content{width:90%;padding:7%}.popup-content input[type="text"],.submit-button{width:100%}}
-:root{--wp-admin-theme-color: #007cba;--wp-admin-theme-color-darker-10: #006ba1;--wp-admin-theme-color-darker-20: #005a87}html[amp] *,html[amp] *:before,html[amp] *:after{-webkit-box-sizing:border-box;box-sizing:border-box}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link{display:none}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit{right:20px}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit{margin-right:0}#wpzoom-recipe-nutrition::after{content:'';clear:both;display:table}#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition-information::after{content:'';clear:both;display:table}#wpzoom-recipe-nutrition.layout-orientation-vertical .wp-block-wpzoom-recipe-card-block-nutrition-information,#wpzoom-recipe-nutrition.layout-orientation-vertical .wp-block-wpzoom-recipe-card-block-nutrition{float:left;width:50%;-webkit-box-sizing:border-box;box-sizing:border-box}#wpzoom-recipe-nutrition.layout-orientation-vertical .wp-block-wpzoom-recipe-card-block-nutrition-information{padding-right:40px}#wpzoom-recipe-nutrition.layout-orientation-vertical .wp-block-wpzoom-recipe-card-block-nutrition-information>.components-base-control{float:left;width:50%;padding-right:20px;-webkit-box-sizing:border-box;box-sizing:border-box}#wpzoom-recipe-nutrition.layout-orientation-vertical .wp-block-wpzoom-recipe-card-block-nutrition-information>.components-base-control .components-base-control__label{font-size:.7em;letter-spacing:.03em;font-weight:700;text-transform:uppercase;line-height:1}#wpzoom-recipe-nutrition.layout-orientation-vertical .wp-block-wpzoom-recipe-card-block-nutrition-information>.components-base-control:nth-child(2n+1){padding-right:0;clear:right}#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition-information,#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition{float:none;width:100%;-webkit-box-sizing:border-box;box-sizing:border-box}#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition-information>.components-base-control{float:left;width:25%;padding-right:20px;-webkit-box-sizing:border-box;box-sizing:border-box}#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition-information>.components-base-control:nth-child(4n+1){padding-right:0;clear:right}
-:root{--wp-admin-theme-color: #007cba;--wp-admin-theme-color-darker-10: #006ba1;--wp-admin-theme-color-darker-20: #005a87}html[amp] *,html[amp] *:before,html[amp] *:after{-webkit-box-sizing:border-box;box-sizing:border-box}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link{display:none}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit{right:20px}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit{margin-right:0}.wpzoom-select-cpt-recipe-cards{min-width:250px}.wpzoom-edit-link-description{margin-top:10px !important;font-size:13px;font-weight:500;margin-left:10px}.Select{position:relative}.Select input::-webkit-contacts-auto-fill-button,.Select input::-webkit-credentials-auto-fill-button{display:none !important}.Select input::-ms-clear,.Select input::-ms-reveal{display:none !important}.Select,.Select div,.Select input,.Select span{-webkit-box-sizing:border-box;box-sizing:border-box}.Select.is-disabled .Select-arrow-zone{cursor:default;pointer-events:none;opacity:.35}.Select.is-disabled>.Select-control{background-color:#f9f9f9}.Select.is-disabled>.Select-control:hover{-webkit-box-shadow:none;box-shadow:none}.Select.is-open>.Select-control{border-bottom-right-radius:0;border-bottom-left-radius:0;background:#fff;border-color:#b3b3b3 #ccc #d9d9d9}.Select.is-open>.Select-control .Select-arrow{top:-2px;border-color:transparent transparent #999;border-width:0 5px 5px}.Select.is-searchable.is-focused:not(.is-open)>.Select-control,.Select.is-searchable.is-open>.Select-control{cursor:text}.Select.is-focused>.Select-control{background:#fff}.Select.is-focused:not(.is-open)>.Select-control{border-color:#007eff;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 0 3px rgba(0,126,255,0.1);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 0 3px rgba(0,126,255,0.1);background:#fff}.Select.has-value.is-clearable.Select--single>.Select-control .Select-value{padding-right:42px}.Select.has-value.is-pseudo-focused.Select--single>.Select-control .Select-value .Select-value-label,.Select.has-value.Select--single>.Select-control .Select-value .Select-value-label{color:#333}.Select.has-value.is-pseudo-focused.Select--single>.Select-control .Select-value a.Select-value-label,.Select.has-value.Select--single>.Select-control .Select-value a.Select-value-label{cursor:pointer;text-decoration:none}.Select.has-value.is-pseudo-focused.Select--single>.Select-control .Select-value a.Select-value-label:focus,.Select.has-value.is-pseudo-focused.Select--single>.Select-control .Select-value a.Select-value-label:hover,.Select.has-value.Select--single>.Select-control .Select-value a.Select-value-label:focus,.Select.has-value.Select--single>.Select-control .Select-value a.Select-value-label:hover{color:#007eff;outline:none;text-decoration:underline}.Select.has-value.is-pseudo-focused.Select--single>.Select-control .Select-value a.Select-value-label:focus,.Select.has-value.Select--single>.Select-control .Select-value a.Select-value-label:focus{background:#fff}.Select.has-value.is-pseudo-focused .Select-input{opacity:0}.Select.is-open .Select-arrow,.Select .Select-arrow-zone:hover>.Select-arrow{border-top-color:#666}.Select.Select--rtl{direction:rtl;text-align:right}.Select-control{background-color:#fff;border-radius:4px;border:1px solid #ccc;color:#333;cursor:default;display:table;border-spacing:0;border-collapse:separate;height:36px;outline:none;overflow:hidden;position:relative;width:100%}.Select-control:hover{-webkit-box-shadow:0 1px 0 rgba(0,0,0,0.06);box-shadow:0 1px 0 rgba(0,0,0,0.06)}.Select-control .Select-input:focus{outline:none;background:#fff}.Select--single>.Select-control .Select-value,.Select-placeholder{bottom:0;color:#aaa;left:0;line-height:34px;padding-left:10px;padding-right:10px;position:absolute;right:0;top:0;max-width:100%;overflow:hidden;-o-text-overflow:ellipsis;text-overflow:ellipsis;white-space:nowrap}.Select-input{height:34px;padding-left:10px;padding-right:10px;vertical-align:middle}.Select-input>input{width:100%;background:none transparent;border:0;-webkit-box-shadow:none;box-shadow:none;cursor:default;display:inline-block;font-family:inherit;font-size:inherit;margin:0;outline:none;line-height:17px;padding:8px 0 12px;-webkit-appearance:none}.is-focused .Select-input>input{cursor:text}.has-value.is-pseudo-focused .Select-input{opacity:0}.Select-control:not(.is-searchable)>.Select-input{outline:none}.Select-loading-zone{cursor:pointer;display:table-cell;text-align:center}.Select-loading,.Select-loading-zone{position:relative;vertical-align:middle;width:16px}.Select-loading{-webkit-animation:Select-animation-spin .4s linear infinite;animation:Select-animation-spin .4s linear infinite;height:16px;-webkit-box-sizing:border-box;box-sizing:border-box;border-radius:50%;border:2px solid #ccc;border-right-color:#333;display:inline-block}.Select-clear-zone{-webkit-animation:Select-animation-fadeIn .2s;animation:Select-animation-fadeIn .2s;color:#999;cursor:pointer;display:table-cell;position:relative;text-align:center;vertical-align:middle;width:17px}.Select-clear-zone:hover{color:#d0021b}.Select-clear{display:inline-block;font-size:18px;line-height:1}.Select--multi .Select-clear-zone{width:17px}.Select-arrow-zone{cursor:pointer;display:table-cell;position:relative;text-align:center;vertical-align:middle;width:25px;padding-right:5px}.Select--rtl .Select-arrow-zone{padding-right:0;padding-left:5px}.Select-arrow{border-color:#999 transparent transparent;border-style:solid;border-width:5px 5px 2.5px;display:inline-block;height:0;width:0;position:relative}.Select-control>:last-child{padding-right:5px}.Select--multi .Select-multi-value-wrapper{display:inline-block}.Select .Select-aria-only{position:absolute;display:inline-block;height:1px;width:1px;margin:-1px;clip:rect(0, 0, 0, 0);overflow:hidden;float:left}@-webkit-keyframes Select-animation-fadeIn{0%{opacity:0}to{opacity:1}}@keyframes Select-animation-fadeIn{0%{opacity:0}to{opacity:1}}.Select-menu-outer{border-bottom-right-radius:4px;border-bottom-left-radius:4px;background-color:#fff;border:1px solid #ccc;border-top-color:#e6e6e6;-webkit-box-shadow:0 1px 0 rgba(0,0,0,0.06);box-shadow:0 1px 0 rgba(0,0,0,0.06);-webkit-box-sizing:border-box;box-sizing:border-box;margin-top:-1px;max-height:200px;position:absolute;left:0;top:100%;width:100%;z-index:1;-webkit-overflow-scrolling:touch}.Select-menu{max-height:198px;overflow-y:auto}.Select-option{-webkit-box-sizing:border-box;box-sizing:border-box;background-color:#fff;color:#666;cursor:pointer;display:block;padding:8px 10px}.Select-option:last-child{border-bottom-right-radius:4px;border-bottom-left-radius:4px}.Select-option.is-selected{background-color:#f5faff;background-color:rgba(0,126,255,0.04);color:#333}.Select-option.is-focused{background-color:#ebf5ff;background-color:rgba(0,126,255,0.08);color:#333}.Select-option.is-disabled{color:#ccc;cursor:default}.Select-noresults{-webkit-box-sizing:border-box;box-sizing:border-box;color:#999;cursor:default;display:block;padding:8px 10px}.Select--multi .Select-input{vertical-align:middle;margin-left:10px;padding:0}.Select--multi.Select--rtl .Select-input{margin-left:0;margin-right:10px}.Select--multi.has-value .Select-input{margin-left:5px}.Select--multi .Select-value{background-color:#ebf5ff;background-color:rgba(0,126,255,0.08);border-radius:2px;border:1px solid #c2e0ff;border:1px solid rgba(0,126,255,0.24);color:#007eff;display:inline-block;font-size:.9em;line-height:1.4;margin-left:5px;margin-top:5px;vertical-align:top}.Select--multi .Select-value-icon,.Select--multi .Select-value-label{display:inline-block;vertical-align:middle}.Select--multi .Select-value-label{border-bottom-right-radius:2px;border-top-right-radius:2px;cursor:default;padding:2px 5px}.Select--multi a.Select-value-label{color:#007eff;cursor:pointer;text-decoration:none}.Select--multi a.Select-value-label:hover{text-decoration:underline}.Select--multi .Select-value-icon{cursor:pointer;border-bottom-left-radius:2px;border-top-left-radius:2px;border-right:1px solid #c2e0ff;border-right:1px solid rgba(0,126,255,0.24);padding:1px 5px 3px}.Select--multi .Select-value-icon:focus,.Select--multi .Select-value-icon:hover{background-color:#d8eafd;background-color:rgba(0,113,230,0.08);color:#0071e6}.Select--multi .Select-value-icon:active{background-color:#c2e0ff;background-color:rgba(0,126,255,0.24)}.Select--multi.Select--rtl .Select-value{margin-left:0;margin-right:5px}.Select--multi.Select--rtl .Select-value-icon{border-right:none;border-left:1px solid #c2e0ff;border-left:1px solid rgba(0,126,255,0.24)}.Select--multi.is-disabled .Select-value{background-color:#fcfcfc;border:1px solid #e3e3e3;color:#333}.Select--multi.is-disabled .Select-value-icon{cursor:not-allowed;border-right:1px solid #e3e3e3}.Select--multi.is-disabled .Select-value-icon:active,.Select--multi.is-disabled .Select-value-icon:focus,.Select--multi.is-disabled .Select-value-icon:hover{background-color:#fcfcfc}@-webkit-keyframes Select-animation-spin{to{-webkit-transform:rotate(1turn);transform:rotate(1turn)}}@keyframes Select-animation-spin{to{-webkit-transform:rotate(1turn);transform:rotate(1turn)}}.gutenbee-icon-block-select-value{display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center}
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * Colors
+ */
+/**
+ * Colors
+ */
+/**
+ * @style: Default
+*/
+/**
+ * @style: Newdesign
+*/
+/**
+ * @style: Simple
+*/
+/**
+ * Colors
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Grid System.
+ * https://make.wordpress.org/design/2019/10/31/proposal-a-consistent-spacing-system-for-wordpress/
+ */
+/**
+ * Dimensions.
+ */
+/**
+ * Shadows.
+ */
+/**
+ * Editor widths.
+ */
+/**
+ * Block UI.
+ */
+/**
+ * Border radii.
+ */
+/**
+ * Breakpoint mixins
+ */
+/**
+ * Long content fade mixin
+ *
+ * Creates a fading overlay to signify that the content is longer
+ * than the space allows.
+ */
+/**
+ * Focus styles.
+ */
+/**
+ * Applies editor left position to the selector passed as argument
+ */
+/**
+ * Styles that are reused verbatim in a few places
+ */
+/**
+ * Allows users to opt-out of animations via OS-level preferences.
+ */
+/**
+ * Reset default styles for JavaScript UI based pages.
+ * This is a WP-admin agnostic reset
+ */
+/**
+ * Reset the WP Admin page styles for Gutenberg-like pages.
+ */
+:root {
+  --wp-admin-theme-color: #007cba;
+  --wp-admin-theme-color-darker-10: #006ba1;
+  --wp-admin-theme-color-darker-20: #005a87; }
+
+/**
+ * Breakpoints & Media Queries
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Border radius.
+ */
+/**
+ * #.# Mixins SCSS
+ *
+ * Mixins allow you to define styles that can be re-used throughout your stylesheet.
+*/
+html[amp] *, html[amp] *:before, html[amp] *:after {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link {
+  display: none; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit {
+  right: 20px; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit {
+  margin-right: 0; }
+
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.wp-block-wpzoom-recipe-card-block-details p.help,
+.wp-block-wpzoom-recipe-card-block-details p.description {
+  font-size: 13px !important;
+  opacity: 0.7;
+  width: 100%;
+  clear: both;
+  float: left;
+  margin-top: 0;
+  margin: 10px 0; }
+
+.wp-block-wpzoom-recipe-card-block-details p.help + p.help,
+.wp-block-wpzoom-recipe-card-block-details p.description + p.description {
+  margin-top: 0; }
+
+.wp-block-wpzoom-recipe-card-block-details .placeholder {
+  opacity: .5;
+  pointer-events: none; }
+
+.wp-block-wpzoom-recipe-card-block-details .details-title {
+  float: none; }
+
+.wp-block-wpzoom-recipe-card-block-details .detail-buttons {
+  clear: both;
+  width: 100%;
+  text-align: center; }
+
+.wp-block-wpzoom-recipe-card-block-details .detail-item-controls-container {
+  display: none;
+  position: absolute;
+  top: 0px;
+  left: -52px;
+  padding: 2px;
+  background-color: #fff;
+  z-index: 10;
+  border: 1px solid #e2e4e7; }
+  .wp-block-wpzoom-recipe-card-block-details .detail-item-controls-container .detail-item-button {
+    display: block; }
+
+.wp-block-wpzoom-recipe-card-block-details .detail-item:focus-within .detail-item-controls-container {
+  display: block; }
+
+.wp-block-wpzoom-recipe-card-block-details .detail-item .detail-item-value {
+  padding: 0;
+  text-align: left; }
+
+.wp-block-wpzoom-recipe-card-block-details .components-icon-button .dashicon + .components-icon-button-text {
+  margin-left: 5px; }
+
+.wpzoom-recipe-card-modal-form .form-group {
+  margin-left: -10px;
+  margin-right: -10px; }
+  .wpzoom-recipe-card-modal-form .form-group::after {
+    content: '';
+    clear: both;
+    display: table; }
+  .wpzoom-recipe-card-modal-form .form-group > .components-base-control {
+    float: left;
+    width: 50%;
+    padding-left: 10px;
+    padding-right: 10px;
+    margin-bottom: 0; }
+    .wpzoom-recipe-card-modal-form .form-group > .components-base-control .components-base-control__label {
+      display: block; }
+
+.wpzoom-recipe-card-modal-form .modal-icons_kit-tab-panel .components-button {
+  background: transparent;
+  border: none;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+  cursor: pointer;
+  padding: 3px 15px;
+  margin-left: 0;
+  font-weight: 400;
+  color: #191e23;
+  outline-offset: -1px;
+  -webkit-transition: -webkit-box-shadow .1s linear;
+  transition: -webkit-box-shadow .1s linear;
+  -o-transition: box-shadow .1s linear;
+  transition: box-shadow .1s linear;
+  transition: box-shadow .1s linear, -webkit-box-shadow .1s linear;
+  height: 40px; }
+  .wpzoom-recipe-card-modal-form .modal-icons_kit-tab-panel .components-button.active-tab {
+    -webkit-box-shadow: inset 0 -3px #007cba;
+            box-shadow: inset 0 -3px #007cba;
+    font-weight: 600;
+    position: relative; }
+
+.wpzoom-recipe-card-icon_kit {
+  padding: 15px 0;
+  margin-top: 10px;
+  border-top: 1px solid #ededed; }
+  .wpzoom-recipe-card-icon_kit::after {
+    content: '';
+    clear: both;
+    display: table; }
+  .wpzoom-recipe-card-icon_kit .wpzoom-recipe-card-icons__single-element {
+    float: left;
+    width: 8%;
+    padding: 5px;
+    margin: 1%;
+    height: 40px;
+    line-height: 30px;
+    text-align: center;
+    background-color: #f0f0f0;
+    border-radius: 2px;
+    cursor: pointer; }
+    .wpzoom-recipe-card-icon_kit .wpzoom-recipe-card-icons__single-element::before {
+      margin: 0;
+      font-size: 20px; }
+    .wpzoom-recipe-card-icon_kit .wpzoom-recipe-card-icons__single-element:hover {
+      -webkit-box-shadow: inset 0 0 0 1px #e2e4e7, inset 0 0 0 2px #fff, 0 1px 1px rgba(25, 30, 35, 0.2);
+              box-shadow: inset 0 0 0 1px #e2e4e7, inset 0 0 0 2px #fff, 0 1px 1px rgba(25, 30, 35, 0.2);
+      background-color: #fff;
+      color: #191e23; }
+    .wpzoom-recipe-card-icon_kit .wpzoom-recipe-card-icons__single-element.icon-element-active {
+      -webkit-box-shadow: inset 0 0 0 1px #007cba, inset 0 0 0 2px #fff;
+              box-shadow: inset 0 0 0 1px #007cba, inset 0 0 0 2px #fff;
+      background-color: #007cba;
+      color: #ffffff; }
+
+#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-details .detail-item-label {
+  font-weight: bold;
+  margin-top: 0;
+  margin-bottom: 0; }
+
+#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-details p {
+  margin-top: 0;
+  margin-bottom: 0; }
+
+#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-details ul,
+#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-details ol {
+  margin: 0;
+  padding: 0; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * Colors
+ */
+/**
+ * Colors
+ */
+/**
+ * @style: Default
+*/
+/**
+ * @style: Newdesign
+*/
+/**
+ * @style: Simple
+*/
+/**
+ * Colors
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Grid System.
+ * https://make.wordpress.org/design/2019/10/31/proposal-a-consistent-spacing-system-for-wordpress/
+ */
+/**
+ * Dimensions.
+ */
+/**
+ * Shadows.
+ */
+/**
+ * Editor widths.
+ */
+/**
+ * Block UI.
+ */
+/**
+ * Border radii.
+ */
+/**
+ * Breakpoint mixins
+ */
+/**
+ * Long content fade mixin
+ *
+ * Creates a fading overlay to signify that the content is longer
+ * than the space allows.
+ */
+/**
+ * Focus styles.
+ */
+/**
+ * Applies editor left position to the selector passed as argument
+ */
+/**
+ * Styles that are reused verbatim in a few places
+ */
+/**
+ * Allows users to opt-out of animations via OS-level preferences.
+ */
+/**
+ * Reset default styles for JavaScript UI based pages.
+ * This is a WP-admin agnostic reset
+ */
+/**
+ * Reset the WP Admin page styles for Gutenberg-like pages.
+ */
+:root {
+  --wp-admin-theme-color: #007cba;
+  --wp-admin-theme-color-darker-10: #006ba1;
+  --wp-admin-theme-color-darker-20: #005a87; }
+
+/**
+ * Breakpoints & Media Queries
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Border radius.
+ */
+/**
+ * #.# Mixins SCSS
+ *
+ * Mixins allow you to define styles that can be re-used throughout your stylesheet.
+*/
+html[amp] *, html[amp] *:before, html[amp] *:after {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link {
+  display: none; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit {
+  right: 20px; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit {
+  margin-right: 0; }
+
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.wp-block-wpzoom-recipe-card-block-directions p.help,
+.wp-block-wpzoom-recipe-card-block-directions p.description {
+  font-size: 13px !important;
+  margin-top: 0;
+  opacity: 0.7; }
+
+.wp-block-wpzoom-recipe-card-block-directions .wpzoom-recipe-card-print-link {
+  right: 0; }
+
+.wp-block-wpzoom-recipe-card-block-directions .direction-step {
+  position: relative;
+  margin: 4px 0;
+  padding: 10px 4px 10px;
+  border: 1px solid #d3d3d3;
+  list-style-type: none;
+  display: -ms-flexbox;
+  display: flex; }
+  .wp-block-wpzoom-recipe-card-block-directions .direction-step .direction-step-group-title {
+    font-weight: bold; }
+  .wp-block-wpzoom-recipe-card-block-directions .direction-step .editor-rich-text,
+  .wp-block-wpzoom-recipe-card-block-directions .direction-step .block-editor-rich-text__editable {
+    display: inline-block;
+    width: 93%; }
+
+.wp-block-wpzoom-recipe-card-block-directions .directions-list > li::before {
+  text-align: center; }
+
+.wp-block-wpzoom-recipe-card-block-directions .direction-step-button-container {
+  display: none;
+  text-align: right; }
+  .wp-block-wpzoom-recipe-card-block-directions .direction-step-button-container button {
+    display: -ms-inline-flexbox;
+    display: inline-flex; }
+
+.wp-block-wpzoom-recipe-card-block-directions .direction-buttons {
+  text-align: center; }
+  .wp-block-wpzoom-recipe-card-block-directions .direction-buttons button {
+    display: -ms-inline-flexbox;
+    display: inline-flex; }
+
+.wp-block-wpzoom-recipe-card-block-directions .direction-buttons button.components-icon-button:not(:disabled):not([aria-disabled=true]):not(.is-default):hover,
+.wp-block-wpzoom-recipe-card-block-directions .direction-step-button-container button.components-icon-button:not(:disabled):not([aria-disabled=true]):not(.is-default):hover {
+  color: #007cba;
+  -webkit-box-shadow: none;
+          box-shadow: none; }
+
+.wp-block-wpzoom-recipe-card-block-directions .direction-step-button-container button.direction-step-button-delete:not(:disabled):not([aria-disabled=true]):not(.is-default):hover {
+  color: #a00; }
+
+.wp-block-wpzoom-recipe-card-block-directions .components-icon-button .dashicon + .components-icon-button-text {
+  margin-left: 5px; }
+
+.wp-block-wpzoom-recipe-card-block-directions .direction-step:focus {
+  outline: none; }
+
+.wp-block-wpzoom-recipe-card-block-directions .direction-step:focus-within .direction-step-button-container {
+  display: -ms-flexbox;
+  display: flex; }
+
+#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-directions .wpzoom-recipe-card-print-link a {
+  color: #a0a0a0; }
+
+#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-directions p {
+  margin-top: 0;
+  margin-bottom: 0; }
+
+#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-directions ul,
+#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-directions ol {
+  margin: 0;
+  padding: 0; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * Colors
+ */
+/**
+ * Colors
+ */
+/**
+ * @style: Default
+*/
+/**
+ * @style: Newdesign
+*/
+/**
+ * @style: Simple
+*/
+/**
+ * Colors
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Grid System.
+ * https://make.wordpress.org/design/2019/10/31/proposal-a-consistent-spacing-system-for-wordpress/
+ */
+/**
+ * Dimensions.
+ */
+/**
+ * Shadows.
+ */
+/**
+ * Editor widths.
+ */
+/**
+ * Block UI.
+ */
+/**
+ * Border radii.
+ */
+/**
+ * Breakpoint mixins
+ */
+/**
+ * Long content fade mixin
+ *
+ * Creates a fading overlay to signify that the content is longer
+ * than the space allows.
+ */
+/**
+ * Focus styles.
+ */
+/**
+ * Applies editor left position to the selector passed as argument
+ */
+/**
+ * Styles that are reused verbatim in a few places
+ */
+/**
+ * Allows users to opt-out of animations via OS-level preferences.
+ */
+/**
+ * Reset default styles for JavaScript UI based pages.
+ * This is a WP-admin agnostic reset
+ */
+/**
+ * Reset the WP Admin page styles for Gutenberg-like pages.
+ */
+:root {
+  --wp-admin-theme-color: #007cba;
+  --wp-admin-theme-color-darker-10: #006ba1;
+  --wp-admin-theme-color-darker-20: #005a87; }
+
+/**
+ * Breakpoints & Media Queries
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Border radius.
+ */
+/**
+ * #.# Mixins SCSS
+ *
+ * Mixins allow you to define styles that can be re-used throughout your stylesheet.
+*/
+html[amp] *, html[amp] *:before, html[amp] *:after {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link {
+  display: none; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit {
+  right: 20px; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit {
+  margin-right: 0; }
+
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.wp-block-wpzoom-recipe-card-block-ingredients p.help,
+.wp-block-wpzoom-recipe-card-block-ingredients p.description {
+  font-size: 13px !important;
+  margin-top: 0;
+  opacity: 0.7; }
+
+.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item {
+  position: relative;
+  list-style-type: none;
+  display: -ms-flexbox;
+  display: flex; }
+  .wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item .editor-rich-text,
+  .wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item .block-editor-rich-text__editable {
+    display: inline-block;
+    width: 93%; }
+  .wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item .ingredient-item-group-title {
+    font-weight: bold; }
+  .wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item:before {
+    display: none !important; }
+
+.wp-block-wpzoom-recipe-card-block-ingredients .ingredients-list > li {
+  cursor: text !important; }
+  .wp-block-wpzoom-recipe-card-block-ingredients .ingredients-list > li .ingredient-item-name:hover {
+    text-decoration: none !important; }
+
+.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item-button-container {
+  display: none;
+  text-align: right; }
+  .wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item-button-container button {
+    display: -ms-inline-flexbox;
+    display: inline-flex; }
+
+.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-buttons {
+  text-align: center; }
+  .wp-block-wpzoom-recipe-card-block-ingredients .ingredient-buttons button {
+    display: -ms-inline-flexbox;
+    display: inline-flex; }
+
+.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-buttons button.components-icon-button:not(:disabled):not([aria-disabled=true]):not(.is-default):hover,
+.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item-button-container button.components-icon-button:not(:disabled):not([aria-disabled=true]):not(.is-default):hover {
+  color: #191e23;
+  -webkit-box-shadow: none;
+          box-shadow: none; }
+
+.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item-button-container button.ingredient-item-button-delete:not(:disabled):not([aria-disabled=true]):not(.is-default):hover {
+  color: #a00; }
+
+.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item-button-container button.components-icon-button:not(:disabled):not([aria-disabled=true]):not(.is-default):hover,
+.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-buttons .components-icon-button:not(:disabled):not([aria-disabled=true]):not(.is-default):hover {
+  background-color: #ece8c8; }
+
+.wp-block-wpzoom-recipe-card-block-ingredients .components-icon-button .dashicon + .components-icon-button-text {
+  margin-left: 5px; }
+
+.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item:focus {
+  outline: none; }
+
+.wp-block-wpzoom-recipe-card-block-ingredients .ingredient-item:focus-within .ingredient-item-button-container {
+  display: -ms-flexbox;
+  display: flex; }
+
+#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-ingredients .wpzoom-recipe-card-print-link a {
+  color: #a0a0a0; }
+
+#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-ingredients p {
+  margin-bottom: 0; }
+
+#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-ingredients ul,
+#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-ingredients ol {
+  margin: 0;
+  padding: 0; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * Colors
+ */
+/**
+ * Colors
+ */
+/**
+ * @style: Default
+*/
+/**
+ * @style: Newdesign
+*/
+/**
+ * @style: Simple
+*/
+/**
+ * Colors
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Grid System.
+ * https://make.wordpress.org/design/2019/10/31/proposal-a-consistent-spacing-system-for-wordpress/
+ */
+/**
+ * Dimensions.
+ */
+/**
+ * Shadows.
+ */
+/**
+ * Editor widths.
+ */
+/**
+ * Block UI.
+ */
+/**
+ * Border radii.
+ */
+/**
+ * Breakpoint mixins
+ */
+/**
+ * Long content fade mixin
+ *
+ * Creates a fading overlay to signify that the content is longer
+ * than the space allows.
+ */
+/**
+ * Focus styles.
+ */
+/**
+ * Applies editor left position to the selector passed as argument
+ */
+/**
+ * Styles that are reused verbatim in a few places
+ */
+/**
+ * Allows users to opt-out of animations via OS-level preferences.
+ */
+/**
+ * Reset default styles for JavaScript UI based pages.
+ * This is a WP-admin agnostic reset
+ */
+/**
+ * Reset the WP Admin page styles for Gutenberg-like pages.
+ */
+:root {
+  --wp-admin-theme-color: #007cba;
+  --wp-admin-theme-color-darker-10: #006ba1;
+  --wp-admin-theme-color-darker-20: #005a87; }
+
+/**
+ * Breakpoints & Media Queries
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Border radius.
+ */
+/**
+ * #.# Mixins SCSS
+ *
+ * Mixins allow you to define styles that can be re-used throughout your stylesheet.
+*/
+html[amp] *, html[amp] *:before, html[amp] *:after {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link {
+  display: none; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit {
+  right: 20px; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit {
+  margin-right: 0; }
+
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.wp-block-wpzoom-recipe-card-block-recipe-card {
+  position: relative; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-loading-block > *:not(.wpzoom-recipe-card-loading-spinner) {
+    display: none; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .components-placeholder.recipe-card-image-placeholder {
+    margin-top: 20px;
+    margin-bottom: 10px; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.recipe-card-noimage .components-placeholder.recipe-card-image-placeholder {
+    display: none; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image-placeholder,
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image-preview {
+    margin-top: 0;
+    margin-bottom: 0;
+    float: left;
+    width: 40%;
+    text-align: left; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image-preview .recipe-card-image {
+    width: 100%;
+    float: none; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.header-content-align-right .recipe-card-image-preview .recipe-card-image {
+    width: 100%;
+    float: none; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.header-content-align-right .recipe-card-image-placeholder,
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.header-content-align-right .recipe-card-image-preview {
+    float: right; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details {
+    margin-bottom: 0; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .details-items .detail-item > .detail-item-icon {
+      display: block; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .details-items .detail-item > div:nth-child(2) {
+      display: block; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .details-items .detail-item > div:nth-child(3), .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .details-items .detail-item div:nth-child(4) {
+      display: inline-block; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .details-items .detail-item .detail-item-value,
+    .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .details-items .detail-item .detail-item-unit {
+      padding: 0;
+      margin-top: 0;
+      text-align: left; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .details-items .detail-item .components-base-control {
+      display: inline-block;
+      margin-right: 5px; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .details-items .detail-item .components-base-control .components-base-control__field {
+        margin-bottom: 0; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .details-items .detail-item .components-base-control .components-base-control__field .components-text-control__input {
+          width: 50px;
+          font-size: 12px;
+          padding: 3px 5px;
+          min-height: auto;
+          height: 26px; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details + p.description {
+      margin-bottom: 10px !important; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .ingredient-item {
+    position: relative;
+    list-style-type: none;
+    display: -ms-flexbox;
+    display: flex; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card .ingredient-item .block-editor-rich-text__editable {
+      display: inline-block;
+      width: 75%; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card .ingredient-item .ingredient-item-group-title {
+      font-weight: bold; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .ingredients-list > li .ingredient-item-name {
+    padding-left: 0 !important; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card .ingredients-list > li .ingredient-item-name:hover {
+      text-decoration: none !important; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .ingredients-list > li .tick-circle {
+    cursor: default !important;
+    display: none !important; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.block-alignment-right .ingredients-list > li .ingredient-item-name {
+    padding-right: 0 !important; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list.layout-2-columns {
+    -webkit-columns: 1 !important;
+       -moz-columns: 1 !important;
+            columns: 1 !important; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .ingredients-list > li, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list > li, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .ingredients-list > li {
+    cursor: text !important; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-summary, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-summary, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-summary {
+    margin-top: 0; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .ingredients-list > li {
+    padding: 0 !important;
+    min-height: 37px; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .ingredient-item-button-container {
+    display: none;
+    text-align: right; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card .ingredient-item-button-container button {
+      display: -ms-inline-flexbox;
+      display: inline-flex;
+      padding: 2px !important;
+      min-width: 30px !important;
+      height: 30px; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .ingredient-buttons {
+    text-align: center; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card .ingredient-buttons button {
+      display: -ms-inline-flexbox;
+      display: inline-flex; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .ingredient-item-button-container button.ingredient-item-button-delete:not(:disabled):not([aria-disabled=true]):not(.is-default):hover {
+    color: #a00; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .ingredient-item:focus {
+    outline: none; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .ingredient-item:focus-within .ingredient-item-button-container {
+    display: -ms-flexbox;
+    display: flex; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .directions-list > li::before {
+    left: 10px;
+    top: 6px; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .direction-step .direction-step-group-title {
+    font-weight: bold; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .direction-step-button-container {
+    display: none;
+    text-align: right; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card .direction-step-button-container button {
+      display: -ms-inline-flexbox;
+      display: inline-flex; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .direction-buttons {
+    text-align: center; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card .direction-buttons button {
+      display: -ms-inline-flexbox;
+      display: inline-flex; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .direction-step-button-container button.direction-step-button-delete:not(:disabled):not([aria-disabled=true]):not(.is-default):hover {
+    color: #a00; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .direction-step:focus {
+    outline: none; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .direction-step:focus-within .direction-step-button-container {
+    display: block; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card p.help,
+  .wp-block-wpzoom-recipe-card-block-recipe-card p.description {
+    font-size: 13px;
+    opacity: 0.7;
+    margin-top: 0;
+    margin-bottom: 10px; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .components-icon-button .dashicon + .components-icon-button-text {
+    margin-left: 5px; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-video .components-placeholder__instructions {
+    display: block; }
+
+.wpzoom-recipe-card-video-settings .editor-video__recipe-card .components-button + .components-button {
+  margin-top: 1em;
+  margin-right: 8px; }
+
+.wpzoom-recipe-card-video-settings .editor-video__url-input-container {
+  position: relative;
+  width: 100%;
+  margin-bottom: 10px; }
+
+.wpzoom-recipe-card-settings .components-base-control__label,
+.wpzoom-recipe-card-seo-settings .components-base-control__label,
+.wpzoom-recipe-card-details .components-base-control__label,
+.wpzoom-recipe-card-structured-data-testing .components-base-control__label {
+  font-weight: 500; }
+  .wpzoom-recipe-card-settings .components-base-control__label + .components-toggle-control,
+  .wpzoom-recipe-card-seo-settings .components-base-control__label + .components-toggle-control,
+  .wpzoom-recipe-card-details .components-base-control__label + .components-toggle-control,
+  .wpzoom-recipe-card-structured-data-testing .components-base-control__label + .components-toggle-control {
+    margin-top: 1em;
+    margin-bottom: 1em; }
+
+.wpzoom-recipe-card-details .components-panel__row {
+  display: block;
+  margin-top: 0;
+  margin-bottom: 15px;
+  padding-bottom: 15px;
+  border-bottom: 1px solid #e2e4e7; }
+  .wpzoom-recipe-card-details .components-panel__row:last-child {
+    border: none;
+    margin: 0;
+    padding: 0; }
+  .wpzoom-recipe-card-details .components-panel__row .components-base-control:nth-child(1) {
+    width: 100%;
+    clear: both;
+    margin-bottom: 10px !important; }
+  .wpzoom-recipe-card-details .components-panel__row .components-base-control:nth-child(2) {
+    padding-right: 5px; }
+  .wpzoom-recipe-card-details .components-panel__row .components-base-control:nth-child(3) {
+    padding-left: 5px; }
+  .wpzoom-recipe-card-details .components-panel__row .components-base-control:nth-child(2),
+  .wpzoom-recipe-card-details .components-panel__row .components-base-control:nth-child(3) {
+    width: 50%;
+    display: inline-block; }
+  .wpzoom-recipe-card-details .components-panel__row .components-base-control {
+    margin-bottom: 0; }
+    .wpzoom-recipe-card-details .components-panel__row .components-base-control .components-base-control__field {
+      margin-bottom: 0; }
+    .wpzoom-recipe-card-details .components-panel__row .components-base-control .components-base-control__label {
+      max-width: 90%;
+      font-weight: 500; }
+    .wpzoom-recipe-card-details .components-panel__row .components-base-control:last-child {
+      margin-bottom: 0 !important; }
+  .wpzoom-recipe-card-details .components-panel__row .editor-calculate-total-time {
+    margin-top: 10px;
+    margin-bottom: 5px; }
+
+.wpzoom-recipe-card-details .components-base-control.components-toggle-control {
+  margin-bottom: 10px; }
+
+.wpzoom-recipe-card-details .components-notice {
+  margin: 5px 0; }
+  .wpzoom-recipe-card-details .components-notice .components-notice__content {
+    margin-right: 0; }
+    .wpzoom-recipe-card-details .components-notice .components-notice__content p:last-child {
+      margin-bottom: 0; }
+  .wpzoom-recipe-card-details .components-notice.is-dismissible {
+    padding: 8px; }
+
+.wpzoom-recipe-card-custom-details .components-panel__row {
+  display: block;
+  margin-top: 0;
+  margin-bottom: 15px;
+  padding-bottom: 15px;
+  border-bottom: 1px solid #e2e4e7; }
+  .wpzoom-recipe-card-custom-details .components-panel__row:last-child {
+    border: none;
+    margin: 0;
+    padding: 0; }
+  .wpzoom-recipe-card-custom-details .components-panel__row .components-base-control:nth-child(1) {
+    width: 100%;
+    clear: both;
+    margin-bottom: 10px !important; }
+  .wpzoom-recipe-card-custom-details .components-panel__row .components-base-control:nth-child(2) {
+    padding-right: 5px; }
+  .wpzoom-recipe-card-custom-details .components-panel__row .components-base-control:nth-child(3) {
+    padding-left: 5px; }
+  .wpzoom-recipe-card-custom-details .components-panel__row .components-base-control:nth-child(2),
+  .wpzoom-recipe-card-custom-details .components-panel__row .components-base-control:nth-child(3) {
+    width: 50%;
+    display: inline-block; }
+  .wpzoom-recipe-card-custom-details .components-panel__row .components-base-control {
+    margin-bottom: 0; }
+    .wpzoom-recipe-card-custom-details .components-panel__row .components-base-control .components-base-control__field {
+      margin-bottom: 0; }
+    .wpzoom-recipe-card-custom-details .components-panel__row .components-base-control .components-base-control__label {
+      max-width: 90%;
+      font-weight: 500; }
+    .wpzoom-recipe-card-custom-details .components-panel__row .components-base-control:last-child {
+      margin-bottom: 0 !important; }
+    .wpzoom-recipe-card-custom-details .components-panel__row .components-base-control.components-toggle-control {
+      margin-top: 20px; }
+      .wpzoom-recipe-card-custom-details .components-panel__row .components-base-control.components-toggle-control .components-base-control__help {
+        margin-top: 10px; }
+
+.wpzoom-recipe-card-settings .components-base-control__help,
+.wpzoom-recipe-card-seo-settings .components-base-control__help,
+.wpzoom-recipe-card-details .components-base-control__help,
+.wpzoom-recipe-card-structured-data-testing .components-base-control__help {
+  margin-top: 0; }
+
+.wpzoom-recipe-card-seo-settings .components-panel__row .components-base-control,
+.wpzoom-recipe-card-details .components-panel__row .components-base-control {
+  margin-bottom: 0; }
+
+.wpzoom-recipe-card-seo-settings .components-panel__row .components-base-control + span,
+.wpzoom-recipe-card-details .components-panel__row .components-base-control + span {
+  margin-top: 1.25em; }
+
+.wpzoom-recipe-card-structured-data-testing .text-color-red {
+  color: #ff2725; }
+
+.wpzoom-recipe-card-structured-data-testing .text-color-orange {
+  color: #ef6c00; }
+
+.wpzoom-recipe-card-structured-data-testing .text-color-green {
+  color: #29a740; }
+
+.wpzoom-recipe-card-structured-data-testing .components-panel__row strong {
+  width: 60%;
+  word-break: break-word; }
+
+.wpzoom-recipe-card-structured-data-testing .components-notice {
+  margin: 5px 0; }
+  .wpzoom-recipe-card-structured-data-testing .components-notice .components-notice__content p:last-child {
+    margin-bottom: 0; }
+
+#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-recipe-card .detail-item-label {
+  font-weight: bold; }
+
+#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-recipe-card p:not(.description) {
+  margin-top: 0;
+  margin-bottom: 0; }
+
+#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-recipe-card ul,
+#wpwrap .edit-post-visual-editor .wp-block-wpzoom-recipe-card-block-recipe-card ol {
+  margin: 0;
+  padding: 0; }
+
+.wpzoom-recipe-card-extra-options .form-group {
+  margin-bottom: 15px;
+  padding-bottom: 15px;
+  border-bottom: 1px solid #ededed; }
+  .wpzoom-recipe-card-extra-options .form-group:last-child {
+    border-bottom: 0;
+    text-align: right; }
+  .wpzoom-recipe-card-extra-options .form-group .wrap-label {
+    margin-bottom: 15px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid #ededed; }
+    .wpzoom-recipe-card-extra-options .form-group .wrap-label label {
+      font-size: 18px;
+      font-weight: 500;
+      line-height: 1.4em;
+      margin-bottom: 5px;
+      display: block; }
+    .wpzoom-recipe-card-extra-options .form-group .wrap-label .description {
+      margin-top: 0;
+      margin-bottom: 0; }
+  .wpzoom-recipe-card-extra-options .form-group .wrap-content .bulk-add-unordered-list,
+  .wpzoom-recipe-card-extra-options .form-group .wrap-content .bulk-add-ordered-list {
+    padding: 10px;
+    border: 1px solid #acacac;
+    border-radius: 3px;
+    height: 150px;
+    overflow-x: scroll; }
+  .wpzoom-recipe-card-extra-options .form-group .wrap-content .bulk-add-unordered-list {
+    margin-bottom: 15px; }
+    .wpzoom-recipe-card-extra-options .form-group .wrap-content .bulk-add-unordered-list li {
+      list-style-type: disc;
+      margin-left: 20px; }
+  .wpzoom-recipe-card-extra-options .form-group .wrap-content .bulk-add-ordered-list li {
+    list-style-type: decimal;
+    margin-left: 20px; }
+  .wpzoom-recipe-card-extra-options .form-group button {
+    margin-right: 10px; }
+    .wpzoom-recipe-card-extra-options .form-group button:last-child {
+      margin-right: 0; }
+
+.wpzoom-recipe-card-extra-options .bulk-add-enter-ingredients label,
+.wpzoom-recipe-card-extra-options .bulk-add-enter-directions label {
+  font-size: 14px;
+  font-weight: bold; }
+
+.wpzoom-recipe-card-extra-options .bulk-add-warning-alert,
+.wpzoom-recipe-card-extra-options .bulk-add-danger-alert {
+  font-style: normal;
+  background: #ffe9e9;
+  padding: 10px;
+  border-radius: 5px;
+  border: 1px solid #ff9090;
+  color: #c00000; }
+
+.wpzoom-recipe-card-extra-options .bulk-add-warning-alert {
+  background: #fef5da;
+  border-color: #fac937;
+  color: #a87f04; }
+
+.components-toolbar button.wpzoom-recipe-card__extra-options {
+  color: #fff !important; }
+  .components-toolbar button.wpzoom-recipe-card__extra-options.is-large {
+    margin: 0 5px; }
+  .components-toolbar button.wpzoom-recipe-card__extra-options.components-icon-button.is-primary:hover {
+    background: #007eb1;
+    border-color: #00435d;
+    color: #fff !important;
+    -webkit-box-shadow: inset 0 -1px 0 #00435d;
+            box-shadow: inset 0 -1px 0 #00435d; }
+
+.components-button svg[size="24"] {
+  width: 24px;
+  height: 24px; }
+
+.wpzoom-recipe-card-settings .components-button.editor-post-featured-image__preview {
+  padding: 0;
+  margin: 0;
+  border: none;
+  outline: none;
+  height: 100%;
+  line-height: 0; }
+
+.wpzoom-recipe-card-settings .components-button-group {
+  display: block; }
+
+.wpzoom-recipe-card-styles .components-panel__body-toggle.components-button,
+.wpzoom-recipe-card-color-scheme .components-panel__body-toggle.components-button,
+.wpzoom-recipe-card-settings .components-panel__body-toggle.components-button,
+.wpzoom-recipe-card-video-settings .components-panel__body-toggle.components-button,
+.wpzoom-recipe-card-food-labels .components-panel__body-toggle.components-button,
+.wpzoom-recipe-card-seo-settings .components-panel__body-toggle.components-button,
+.wpzoom-recipe-card-details .components-panel__body-toggle.components-button,
+.wpzoom-recipe-card-custom-details .components-panel__body-toggle.components-button,
+.wpzoom-recipe-card-structured-data-testing .components-panel__body-toggle.components-button {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-direction: row-reverse;
+      flex-direction: row-reverse;
+  -ms-flex-pack: end;
+      justify-content: flex-end; }
+
+.wpzoom-recipe-card-styles .components-panel__body-toggle svg.components-panel__icon,
+.wpzoom-recipe-card-color-scheme .components-panel__body-toggle svg.components-panel__icon,
+.wpzoom-recipe-card-settings .components-panel__body-toggle svg.components-panel__icon,
+.wpzoom-recipe-card-video-settings .components-panel__body-toggle svg.components-panel__icon,
+.wpzoom-recipe-card-food-labels .components-panel__body-toggle svg.components-panel__icon,
+.wpzoom-recipe-card-seo-settings .components-panel__body-toggle svg.components-panel__icon,
+.wpzoom-recipe-card-details .components-panel__body-toggle svg.components-panel__icon,
+.wpzoom-recipe-card-custom-details .components-panel__body-toggle svg.components-panel__icon,
+.wpzoom-recipe-card-structured-data-testing .components-panel__body-toggle svg.components-panel__icon {
+  width: 20px;
+  height: 20px;
+  margin: 0 10px 0 0;
+  fill: #2ea55f; }
+
+.ai-button {
+  background-color: white;
+  color: #E1581A;
+  border: 2px solid #E1581A;
+  padding: 14px 40px;
+  cursor: pointer;
+  -webkit-transition: background-color 0.3s, color 0.3s;
+  -o-transition: background-color 0.3s, color 0.3s;
+  transition: background-color 0.3s, color 0.3s;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  margin-left: auto !important;
+  display: block;
+  border-radius: 5px;
+  font-weight: 600 !important;
+  padding: 15px 20px 35px 20px !important; }
+  .ai-button:hover {
+    background-color: #E1581A;
+    color: white !important; }
+    .ai-button:hover svg path {
+      fill: white; }
+  .ai-button svg {
+    margin-right: 10px; }
+
+.popup-overlay {
+  position: fixed !important;
+  top: 0 !important;
+  left: 0 !important;
+  background: #00000055;
+  -webkit-transform: none !important;
+      -ms-transform: none !important;
+          transform: none !important;
+  width: 100%;
+  height: 100%;
+  z-index: 999; }
+
+.popup-content {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%, -50%);
+      -ms-transform: translate(-50%, -50%);
+          transform: translate(-50%, -50%);
+  background-color: #fff;
+  padding: 40px 60px;
+  border: 2px solid #F2F4F6;
+  border-radius: 10px;
+  width: 570px;
+  -webkit-box-shadow: 0 15px 25px 0 rgba(0, 0, 0, 0.05);
+          box-shadow: 0 15px 25px 0 rgba(0, 0, 0, 0.05); }
+  .popup-content h2 {
+    font-size: 18px;
+    color: #041728;
+    margin-top: 35px;
+    font-weight: 600; }
+  .popup-content ul li {
+    font-size: 16px;
+    line-height: 1.4;
+    font-weight: 400;
+    color: #E1581A; }
+  .popup-content input[type="text"] {
+    font-size: 20px;
+    color: var(--rcb-dark, #041728);
+    padding: 10px 10px 10px 70px;
+    border-radius: 4px;
+    margin: 0 0 20px 0;
+    border: 1px solid #7C848A;
+    width: 440px;
+    height: 47px;
+    border: 1px solid var(--rcb-grey, #7C848A);
+    background: var(--white, #FFF); }
+
+.submit-button {
+  font-size: 22px;
+  background-color: #f34b00 !important;
+  color: #fff;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-align: center;
+      align-items: center;
+  -ms-flex-pack: center;
+      justify-content: center;
+  height: 60px;
+  font-weight: 500;
+  width: 440px;
+  padding: 14px;
+  justify-content: center;
+  border-radius: 5px;
+  background: var(--main-color, #E1581A); }
+  .submit-button:hover {
+    background-color: #c03b00 !important; }
+  .submit-button span {
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-align: center;
+        align-items: center; }
+    .submit-button span svg {
+      height: 26px;
+      width: 26px;
+      margin-right: 16px; }
+
+.manual-button {
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  margin-left: auto !important;
+  display: block;
+  color: #7C848A;
+  border: 2px solid #7C848A;
+  background-color: white;
+  border-radius: 5px;
+  font-weight: 500;
+  font-size: 14px !important; }
+
+.components-button.ai-button {
+  position: relative; }
+  .components-button.ai-button span.btn-svg {
+    position: absolute;
+    top: 8px; }
+  .components-button.ai-button span.btn-text {
+    padding-left: 20px;
+    font-size: 15px;
+    font-weight: 500; }
+
+.components-button.regenerate-recipe-button {
+  padding: 0 0 0 0;
+  font-size: 14px;
+  font-weight: 600; }
+  .components-button.regenerate-recipe-button span.btn-text {
+    color: #E1581A;
+    font-size: 12px;
+    font-weight: 600; }
+  .components-button.regenerate-recipe-button span.btn-svg {
+    margin: 0 5px 0 0; }
+
+.svg-input {
+  position: relative; }
+  .svg-input span svg {
+    position: absolute;
+    top: 14px;
+    left: 20px; }
+
+.Content-suggestions {
+  text-align: center; }
+  .Content-suggestions h4 {
+    color: #041728;
+    font-size: 15px;
+    margin: 25px 0 15px 0;
+    opacity: 1;
+    text-align: left; }
+  .Content-suggestions ul {
+    text-align: left; }
+    .Content-suggestions ul li {
+      opacity: 1;
+      cursor: pointer; }
+
+.page-loader {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(255, 255, 255, 0.8);
+  /* Semi-transparent white background */
+  z-index: 9999;
+  /* Ensure it's above other elements */ }
+
+@-webkit-keyframes spin {
+  0% {
+    -webkit-transform: translate(-50%, -50%) rotate(0deg);
+            transform: translate(-50%, -50%) rotate(0deg); }
+  100% {
+    -webkit-transform: translate(-50%, -50%) rotate(360deg);
+            transform: translate(-50%, -50%) rotate(360deg); } }
+
+@keyframes spin {
+  0% {
+    -webkit-transform: translate(-50%, -50%) rotate(0deg);
+            transform: translate(-50%, -50%) rotate(0deg); }
+  100% {
+    -webkit-transform: translate(-50%, -50%) rotate(360deg);
+            transform: translate(-50%, -50%) rotate(360deg); } }
+
+.wp-block-wpzoom-recipe-card-block-recipe-card.image-loader .recipe-card-image-placeholder,
+.wp-block-wpzoom-recipe-card-block-recipe-card.image-loader .recipe-card-image-preview,
+.loader {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-pack: center;
+      justify-content: center;
+  -ms-flex-align: center;
+      align-items: center;
+  z-index: 9999999;
+  /* Ensure it's on top */ }
+
+.wp-block-wpzoom-recipe-card-block-recipe-card.image-loader .recipe-card-image-placeholder,
+.wp-block-wpzoom-recipe-card-block-recipe-card.image-loader .recipe-card-image-preview {
+  position: relative;
+  min-height: 200px;
+  -webkit-box-shadow: none;
+          box-shadow: none; }
+
+.wp-block-wpzoom-recipe-card-block-recipe-card.image-loader .recipe-card-image-placeholder div,
+.wp-block-wpzoom-recipe-card-block-recipe-card.image-loader .recipe-card-image-preview div {
+  display: none; }
+
+.recipe-image-placeholder-wrapper .loader {
+  position: absolute; }
+
+.wp-block-wpzoom-recipe-card-block-recipe-card.image-loader .recipe-card-image-placeholder::after,
+.wp-block-wpzoom-recipe-card-block-recipe-card.image-loader .recipe-card-image-preview::after,
+.loader::after {
+  content: "";
+  border: 4px solid rgba(255, 255, 255, 0.3);
+  /* Light grey */
+  border-top: 4px solid #E1581A;
+  /* Orange */
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  -webkit-animation: spin 1s linear infinite;
+          animation: spin 1s linear infinite; }
+
+.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image-preview .recipe-card-image {
+  margin: 10px 0; }
+
+@keyframes spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+            transform: rotate(0deg); }
+  100% {
+    -webkit-transform: rotate(360deg);
+            transform: rotate(360deg); } }
+
+@keyframes spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+            transform: rotate(0deg); }
+  100% {
+    -webkit-transform: rotate(360deg);
+            transform: rotate(360deg); } }
+
+#inspector-text-control-0:focus {
+  border: 1px solid var(--rcb-grey, #7C848A); }
+
+#inspector-text-control-0::-webkit-input-placeholder {
+  color: #c4b8b8; }
+
+#inspector-text-control-0::-moz-placeholder {
+  color: #c4b8b8; }
+
+#inspector-text-control-0::-ms-input-placeholder {
+  color: #c4b8b8; }
+
+#inspector-text-control-0::placeholder {
+  color: #c4b8b8; }
+
+.manual-button:active, .manual-button:hover {
+  border-radius: 5px;
+  border: 2px solid var(--rcb-grey, #7C848A);
+  color: #7C848A; }
+
+.components-button.ai-button span.btn-text {
+  font-weight: 600 !important;
+  padding-left: 28px; }
+
+.components-button.ai-button span.btn-svg {
+  top: 15px; }
+
+.use-recipe-image-prompt {
+  margin: 0 0 25px 0; }
+
+.use-recipe-image-prompt .components-checkbox-control__input[type=checkbox]:checked,
+.use-recipe-image-prompt .components-checkbox-control__input[type=checkbox]:indeterminate {
+  background-color: #E1581A;
+  border-color: #E1581A; }
+
+.wp-block .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-header-wrap {
+  margin-top: 20px !important; }
+
+.wp-block .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image {
+  margin-top: 20px; }
+
+.wp-block .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-mint .recipe-card-header-container {
+  margin-top: 20px !important; }
+
+.wp-block .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-mint .ai-button {
+  margin-right: auto !important;
+  margin-left: 0 !important; }
+
+.wp-block .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-accent-color-header .recipe-card-header-container {
+  margin-top: 20px !important; }
+
+.close-button {
+  position: absolute;
+  top: -10px;
+  right: -10px;
+  width: 26px;
+  height: 26px;
+  background-color: #f34b00;
+  cursor: pointer;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #ffffff;
+  border-radius: 20px;
+  padding: 0 4px 1px 5px;
+  border: none; }
+  .close-button span {
+    margin: 1px 1px 0 0; }
+
+.submit-button {
+  opacity: 1;
+  -webkit-transition: opacity 0.3s ease;
+  -o-transition: opacity 0.3s ease;
+  transition: opacity 0.3s ease;
+  cursor: pointer; }
+
+.submit-button.disabled {
+  opacity: 0.5;
+  cursor: not-allowed; }
+
+.calculate-nutr {
+  background-color: white;
+  color: #E1581A;
+  border: 2px solid #E1581A;
+  cursor: pointer;
+  -o-transition: background-color 0.3s, color 0.3s;
+  margin-left: auto !important;
+  display: block;
+  border-radius: 5px;
+  font-weight: 600 !important;
+  padding: 10px 30px 30px 30px !important;
+  margin-right: 100px;
+  font-size: 15px; }
+
+.popup-content-error {
+  border-radius: 6px !important;
+  width: 475px;
+  padding: 0; }
+
+.popup-content-error h4 {
+  border-radius: 0px !important;
+  font-size: 20px;
+  text-align: center;
+  line-height: 1.5em; }
+
+.popup-content-error .error-close-btn {
+  background: white;
+  color: #8080809e;
+  right: 20px;
+  top: 15px; }
+
+.popup-content-error .error-close-btn span {
+  font-size: 30px !important; }
+
+.popup-content-error .Content-suggestions p {
+  text-align: center;
+  font-size: 14px; }
+
+.popup-content-error .Content-suggestions {
+  padding: 50px 30px 30px; }
+
+button.components-button.try-again,
+.components-button.buyMore,
+button.components-button.activate-license {
+  margin: 0 auto;
+  display: block;
+  background-color: #E1581A;
+  color: #fff;
+  width: 100%;
+  border-radius: 3px;
+  font-size: 15px;
+  height: 40px;
+  margin-top: 80px; }
+
+.popup-content-error a.try-again,
+.components-button.buyMore,
+.popup-content-error a.activate-license {
+  margin: 0 auto;
+  display: block;
+  background-color: #E1581A;
+  color: #fff;
+  width: 100%;
+  border-radius: 3px;
+  font-size: 15px;
+  height: 40px;
+  margin-top: 20px;
+  text-align: center;
+  padding: 10px; }
+
+.components-button.buyMore:active {
+  color: #fff; }
+
+.components-button.buyMore:hover {
+  background-color: #000 !important; }
+
+.popup-content-error a.activate-license,
+button.components-button.activate-license {
+  margin-top: 0; }
+
+.popup-content-error a.try-again span.btn-text,
+.popup-content-error a.activate-license span.btn-text {
+  color: white;
+  font-size: 15px;
+  text-align: center;
+  margin: 0 auto; }
+
+.popup-svg {
+  width: 100px;
+  display: block;
+  margin: 0 auto;
+  background: #ffe7d4;
+  border-radius: 3px;
+  padding: 10px 10px 10px 10px; }
+
+.popup-svg .error-svg {
+  display: block;
+  margin: 0 auto; }
+
+.popup-content-error .ai-credits-error {
+  padding: 35px 35px 30px !important; }
+
+.popup-content-error a.ai-error {
+  margin: 0px !important; }
+
+span.ai-error {
+  width: 100%;
+  display: block;
+  padding: 30px 0px 30px 0px;
+  margin-top: 40px;
+  text-align: center; }
+
+span.ai-error a {
+  text-align: center;
+  color: #E1581A;
+  font-size: 15px;
+  text-decoration: underline; }
+
+p.ai-p {
+  padding: 0px 20px 0px 20px; }
+
+@media only screen and (max-width: 640px) {
+  .popup-content {
+    width: 90%;
+    padding: 7%; }
+  .popup-content input[type="text"],
+  .submit-button {
+    width: 100%; } }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * Colors
+ */
+/**
+ * Colors
+ */
+/**
+ * @style: Default
+*/
+/**
+ * @style: Newdesign
+*/
+/**
+ * @style: Simple
+*/
+/**
+ * Colors
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Grid System.
+ * https://make.wordpress.org/design/2019/10/31/proposal-a-consistent-spacing-system-for-wordpress/
+ */
+/**
+ * Dimensions.
+ */
+/**
+ * Shadows.
+ */
+/**
+ * Editor widths.
+ */
+/**
+ * Block UI.
+ */
+/**
+ * Border radii.
+ */
+/**
+ * Breakpoint mixins
+ */
+/**
+ * Long content fade mixin
+ *
+ * Creates a fading overlay to signify that the content is longer
+ * than the space allows.
+ */
+/**
+ * Focus styles.
+ */
+/**
+ * Applies editor left position to the selector passed as argument
+ */
+/**
+ * Styles that are reused verbatim in a few places
+ */
+/**
+ * Allows users to opt-out of animations via OS-level preferences.
+ */
+/**
+ * Reset default styles for JavaScript UI based pages.
+ * This is a WP-admin agnostic reset
+ */
+/**
+ * Reset the WP Admin page styles for Gutenberg-like pages.
+ */
+:root {
+  --wp-admin-theme-color: #007cba;
+  --wp-admin-theme-color-darker-10: #006ba1;
+  --wp-admin-theme-color-darker-20: #005a87; }
+
+/**
+ * Breakpoints & Media Queries
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Border radius.
+ */
+/**
+ * #.# Mixins SCSS
+ *
+ * Mixins allow you to define styles that can be re-used throughout your stylesheet.
+*/
+html[amp] *, html[amp] *:before, html[amp] *:after {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link {
+  display: none; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit {
+  right: 20px; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit {
+  margin-right: 0; }
+
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+#wpzoom-recipe-nutrition::after {
+  content: '';
+  clear: both;
+  display: table; }
+
+#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition-information::after {
+  content: '';
+  clear: both;
+  display: table; }
+
+#wpzoom-recipe-nutrition.layout-orientation-vertical .wp-block-wpzoom-recipe-card-block-nutrition-information,
+#wpzoom-recipe-nutrition.layout-orientation-vertical .wp-block-wpzoom-recipe-card-block-nutrition {
+  float: left;
+  width: 50%;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box; }
+
+#wpzoom-recipe-nutrition.layout-orientation-vertical .wp-block-wpzoom-recipe-card-block-nutrition-information {
+  padding-right: 40px; }
+  #wpzoom-recipe-nutrition.layout-orientation-vertical .wp-block-wpzoom-recipe-card-block-nutrition-information > .components-base-control {
+    float: left;
+    width: 50%;
+    padding-right: 20px;
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box; }
+    #wpzoom-recipe-nutrition.layout-orientation-vertical .wp-block-wpzoom-recipe-card-block-nutrition-information > .components-base-control .components-base-control__label {
+      font-size: .7em;
+      letter-spacing: .03em;
+      font-weight: 700;
+      text-transform: uppercase;
+      line-height: 1; }
+    #wpzoom-recipe-nutrition.layout-orientation-vertical .wp-block-wpzoom-recipe-card-block-nutrition-information > .components-base-control:nth-child(2n+1) {
+      padding-right: 0;
+      clear: right; }
+
+#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition-information,
+#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition {
+  float: none;
+  width: 100%;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box; }
+
+#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition-information > .components-base-control {
+  float: left;
+  width: 25%;
+  padding-right: 20px;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box; }
+  #wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition-information > .components-base-control:nth-child(4n+1) {
+    padding-right: 0;
+    clear: right; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * Colors
+ */
+/**
+ * Colors
+ */
+/**
+ * @style: Default
+*/
+/**
+ * @style: Newdesign
+*/
+/**
+ * @style: Simple
+*/
+/**
+ * Colors
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Grid System.
+ * https://make.wordpress.org/design/2019/10/31/proposal-a-consistent-spacing-system-for-wordpress/
+ */
+/**
+ * Dimensions.
+ */
+/**
+ * Shadows.
+ */
+/**
+ * Editor widths.
+ */
+/**
+ * Block UI.
+ */
+/**
+ * Border radii.
+ */
+/**
+ * Breakpoint mixins
+ */
+/**
+ * Long content fade mixin
+ *
+ * Creates a fading overlay to signify that the content is longer
+ * than the space allows.
+ */
+/**
+ * Focus styles.
+ */
+/**
+ * Applies editor left position to the selector passed as argument
+ */
+/**
+ * Styles that are reused verbatim in a few places
+ */
+/**
+ * Allows users to opt-out of animations via OS-level preferences.
+ */
+/**
+ * Reset default styles for JavaScript UI based pages.
+ * This is a WP-admin agnostic reset
+ */
+/**
+ * Reset the WP Admin page styles for Gutenberg-like pages.
+ */
+:root {
+  --wp-admin-theme-color: #007cba;
+  --wp-admin-theme-color-darker-10: #006ba1;
+  --wp-admin-theme-color-darker-20: #005a87; }
+
+/**
+ * Breakpoints & Media Queries
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Border radius.
+ */
+/**
+ * #.# Mixins SCSS
+ *
+ * Mixins allow you to define styles that can be re-used throughout your stylesheet.
+*/
+html[amp] *, html[amp] *:before, html[amp] *:after {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link {
+  display: none; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit {
+  right: 20px; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit {
+  margin-right: 0; }
+
+.wpzoom-select-cpt-recipe-cards {
+  min-width: 250px; }
+
+.wpzoom-edit-link-description {
+  margin-top: 10px !important;
+  font-size: 13px;
+  font-weight: 500;
+  margin-left: 10px; }
+
+.Select {
+  position: relative; }
+
+.Select input::-webkit-contacts-auto-fill-button, .Select input::-webkit-credentials-auto-fill-button {
+  display: none !important; }
+
+.Select input::-ms-clear, .Select input::-ms-reveal {
+  display: none !important; }
+
+.Select, .Select div, .Select input, .Select span {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box; }
+
+.Select.is-disabled .Select-arrow-zone {
+  cursor: default;
+  pointer-events: none;
+  opacity: .35; }
+
+.Select.is-disabled > .Select-control {
+  background-color: #f9f9f9; }
+
+.Select.is-disabled > .Select-control:hover {
+  -webkit-box-shadow: none;
+          box-shadow: none; }
+
+.Select.is-open > .Select-control {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+  background: #fff;
+  border-color: #b3b3b3 #ccc #d9d9d9; }
+
+.Select.is-open > .Select-control .Select-arrow {
+  top: -2px;
+  border-color: transparent transparent #999;
+  border-width: 0 5px 5px; }
+
+.Select.is-searchable.is-focused:not(.is-open) > .Select-control, .Select.is-searchable.is-open > .Select-control {
+  cursor: text; }
+
+.Select.is-focused > .Select-control {
+  background: #fff; }
+
+.Select.is-focused:not(.is-open) > .Select-control {
+  border-color: #007eff;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 0 3px rgba(0, 126, 255, 0.1);
+          box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 0 3px rgba(0, 126, 255, 0.1);
+  background: #fff; }
+
+.Select.has-value.is-clearable.Select--single > .Select-control .Select-value {
+  padding-right: 42px; }
+
+.Select.has-value.is-pseudo-focused.Select--single > .Select-control .Select-value .Select-value-label, .Select.has-value.Select--single > .Select-control .Select-value .Select-value-label {
+  color: #333; }
+
+.Select.has-value.is-pseudo-focused.Select--single > .Select-control .Select-value a.Select-value-label, .Select.has-value.Select--single > .Select-control .Select-value a.Select-value-label {
+  cursor: pointer;
+  text-decoration: none; }
+
+.Select.has-value.is-pseudo-focused.Select--single > .Select-control .Select-value a.Select-value-label:focus, .Select.has-value.is-pseudo-focused.Select--single > .Select-control .Select-value a.Select-value-label:hover, .Select.has-value.Select--single > .Select-control .Select-value a.Select-value-label:focus, .Select.has-value.Select--single > .Select-control .Select-value a.Select-value-label:hover {
+  color: #007eff;
+  outline: none;
+  text-decoration: underline; }
+
+.Select.has-value.is-pseudo-focused.Select--single > .Select-control .Select-value a.Select-value-label:focus, .Select.has-value.Select--single > .Select-control .Select-value a.Select-value-label:focus {
+  background: #fff; }
+
+.Select.has-value.is-pseudo-focused .Select-input {
+  opacity: 0; }
+
+.Select.is-open .Select-arrow, .Select .Select-arrow-zone:hover > .Select-arrow {
+  border-top-color: #666; }
+
+.Select.Select--rtl {
+  direction: rtl;
+  text-align: right; }
+
+.Select-control {
+  background-color: #fff;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  color: #333;
+  cursor: default;
+  display: table;
+  border-spacing: 0;
+  border-collapse: separate;
+  height: 36px;
+  outline: none;
+  overflow: hidden;
+  position: relative;
+  width: 100%; }
+
+.Select-control:hover {
+  -webkit-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.06);
+          box-shadow: 0 1px 0 rgba(0, 0, 0, 0.06); }
+
+.Select-control .Select-input:focus {
+  outline: none;
+  background: #fff; }
+
+.Select--single > .Select-control .Select-value, .Select-placeholder {
+  bottom: 0;
+  color: #aaa;
+  left: 0;
+  line-height: 34px;
+  padding-left: 10px;
+  padding-right: 10px;
+  position: absolute;
+  right: 0;
+  top: 0;
+  max-width: 100%;
+  overflow: hidden;
+  -o-text-overflow: ellipsis;
+     text-overflow: ellipsis;
+  white-space: nowrap; }
+
+.Select-input {
+  height: 34px;
+  padding-left: 10px;
+  padding-right: 10px;
+  vertical-align: middle; }
+
+.Select-input > input {
+  width: 100%;
+  background: none transparent;
+  border: 0;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+  cursor: default;
+  display: inline-block;
+  font-family: inherit;
+  font-size: inherit;
+  margin: 0;
+  outline: none;
+  line-height: 17px;
+  padding: 8px 0 12px;
+  -webkit-appearance: none; }
+
+.is-focused .Select-input > input {
+  cursor: text; }
+
+.has-value.is-pseudo-focused .Select-input {
+  opacity: 0; }
+
+.Select-control:not(.is-searchable) > .Select-input {
+  outline: none; }
+
+.Select-loading-zone {
+  cursor: pointer;
+  display: table-cell;
+  text-align: center; }
+
+.Select-loading, .Select-loading-zone {
+  position: relative;
+  vertical-align: middle;
+  width: 16px; }
+
+.Select-loading {
+  -webkit-animation: Select-animation-spin .4s linear infinite;
+          animation: Select-animation-spin .4s linear infinite;
+  height: 16px;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  border-radius: 50%;
+  border: 2px solid #ccc;
+  border-right-color: #333;
+  display: inline-block; }
+
+.Select-clear-zone {
+  -webkit-animation: Select-animation-fadeIn .2s;
+          animation: Select-animation-fadeIn .2s;
+  color: #999;
+  cursor: pointer;
+  display: table-cell;
+  position: relative;
+  text-align: center;
+  vertical-align: middle;
+  width: 17px; }
+
+.Select-clear-zone:hover {
+  color: #d0021b; }
+
+.Select-clear {
+  display: inline-block;
+  font-size: 18px;
+  line-height: 1; }
+
+.Select--multi .Select-clear-zone {
+  width: 17px; }
+
+.Select-arrow-zone {
+  cursor: pointer;
+  display: table-cell;
+  position: relative;
+  text-align: center;
+  vertical-align: middle;
+  width: 25px;
+  padding-right: 5px; }
+
+.Select--rtl .Select-arrow-zone {
+  padding-right: 0;
+  padding-left: 5px; }
+
+.Select-arrow {
+  border-color: #999 transparent transparent;
+  border-style: solid;
+  border-width: 5px 5px 2.5px;
+  display: inline-block;
+  height: 0;
+  width: 0;
+  position: relative; }
+
+.Select-control > :last-child {
+  padding-right: 5px; }
+
+.Select--multi .Select-multi-value-wrapper {
+  display: inline-block; }
+
+.Select .Select-aria-only {
+  position: absolute;
+  display: inline-block;
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  clip: rect(0, 0, 0, 0);
+  overflow: hidden;
+  float: left; }
+
+@-webkit-keyframes Select-animation-fadeIn {
+  0% {
+    opacity: 0; }
+  to {
+    opacity: 1; } }
+
+@keyframes Select-animation-fadeIn {
+  0% {
+    opacity: 0; }
+  to {
+    opacity: 1; } }
+
+.Select-menu-outer {
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  border-top-color: #e6e6e6;
+  -webkit-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.06);
+          box-shadow: 0 1px 0 rgba(0, 0, 0, 0.06);
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  margin-top: -1px;
+  max-height: 200px;
+  position: absolute;
+  left: 0;
+  top: 100%;
+  width: 100%;
+  z-index: 1;
+  -webkit-overflow-scrolling: touch; }
+
+.Select-menu {
+  max-height: 198px;
+  overflow-y: auto; }
+
+.Select-option {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  background-color: #fff;
+  color: #666;
+  cursor: pointer;
+  display: block;
+  padding: 8px 10px; }
+
+.Select-option:last-child {
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px; }
+
+.Select-option.is-selected {
+  background-color: #f5faff;
+  background-color: rgba(0, 126, 255, 0.04);
+  color: #333; }
+
+.Select-option.is-focused {
+  background-color: #ebf5ff;
+  background-color: rgba(0, 126, 255, 0.08);
+  color: #333; }
+
+.Select-option.is-disabled {
+  color: #ccc;
+  cursor: default; }
+
+.Select-noresults {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  color: #999;
+  cursor: default;
+  display: block;
+  padding: 8px 10px; }
+
+.Select--multi .Select-input {
+  vertical-align: middle;
+  margin-left: 10px;
+  padding: 0; }
+
+.Select--multi.Select--rtl .Select-input {
+  margin-left: 0;
+  margin-right: 10px; }
+
+.Select--multi.has-value .Select-input {
+  margin-left: 5px; }
+
+.Select--multi .Select-value {
+  background-color: #ebf5ff;
+  background-color: rgba(0, 126, 255, 0.08);
+  border-radius: 2px;
+  border: 1px solid #c2e0ff;
+  border: 1px solid rgba(0, 126, 255, 0.24);
+  color: #007eff;
+  display: inline-block;
+  font-size: .9em;
+  line-height: 1.4;
+  margin-left: 5px;
+  margin-top: 5px;
+  vertical-align: top; }
+
+.Select--multi .Select-value-icon, .Select--multi .Select-value-label {
+  display: inline-block;
+  vertical-align: middle; }
+
+.Select--multi .Select-value-label {
+  border-bottom-right-radius: 2px;
+  border-top-right-radius: 2px;
+  cursor: default;
+  padding: 2px 5px; }
+
+.Select--multi a.Select-value-label {
+  color: #007eff;
+  cursor: pointer;
+  text-decoration: none; }
+
+.Select--multi a.Select-value-label:hover {
+  text-decoration: underline; }
+
+.Select--multi .Select-value-icon {
+  cursor: pointer;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-right: 1px solid #c2e0ff;
+  border-right: 1px solid rgba(0, 126, 255, 0.24);
+  padding: 1px 5px 3px; }
+
+.Select--multi .Select-value-icon:focus, .Select--multi .Select-value-icon:hover {
+  background-color: #d8eafd;
+  background-color: rgba(0, 113, 230, 0.08);
+  color: #0071e6; }
+
+.Select--multi .Select-value-icon:active {
+  background-color: #c2e0ff;
+  background-color: rgba(0, 126, 255, 0.24); }
+
+.Select--multi.Select--rtl .Select-value {
+  margin-left: 0;
+  margin-right: 5px; }
+
+.Select--multi.Select--rtl .Select-value-icon {
+  border-right: none;
+  border-left: 1px solid #c2e0ff;
+  border-left: 1px solid rgba(0, 126, 255, 0.24); }
+
+.Select--multi.is-disabled .Select-value {
+  background-color: #fcfcfc;
+  border: 1px solid #e3e3e3;
+  color: #333; }
+
+.Select--multi.is-disabled .Select-value-icon {
+  cursor: not-allowed;
+  border-right: 1px solid #e3e3e3; }
+
+.Select--multi.is-disabled .Select-value-icon:active, .Select--multi.is-disabled .Select-value-icon:focus, .Select--multi.is-disabled .Select-value-icon:hover {
+  background-color: #fcfcfc; }
+
+@-webkit-keyframes Select-animation-spin {
+  to {
+    -webkit-transform: rotate(1turn);
+            transform: rotate(1turn); } }
+
+@keyframes Select-animation-spin {
+  to {
+    -webkit-transform: rotate(1turn);
+            transform: rotate(1turn); } }
+
+.gutenbee-icon-block-select-value {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-align: center;
+      align-items: center; }

--- a/dist/blocks.style.build.css
+++ b/dist/blocks.style.build.css
@@ -1,8 +1,2856 @@
-:root{--wp-admin-theme-color: #007cba;--wp-admin-theme-color-darker-10: #006ba1;--wp-admin-theme-color-darker-20: #005a87}html[amp] *,html[amp] *:before,html[amp] *:after{-webkit-box-sizing:border-box;box-sizing:border-box}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link{display:none}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit{right:20px}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit{margin-right:0}.wp-block-wpzoom-recipe-card-block-details{position:relative;margin:0;padding:20px 0;text-align:left;max-width:750px}.wp-block-wpzoom-recipe-card-block-details .details-title{font-size:22px;font-weight:600;color:inherit;margin:0 0 20px;padding:0;background-color:transparent;font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"}.wp-block-wpzoom-recipe-card-block-details::after{content:'';clear:both;display:table}.wp-block-wpzoom-recipe-card-block-details .details-items::after{content:'';clear:both;display:table}.wp-block-wpzoom-recipe-card-block-details .detail-item-icon{display:block}.wp-block-wpzoom-recipe-card-block-details .detail-item-icon::before{color:#222}.wp-block-wpzoom-recipe-card-block-details .detail-item-icon svg{fill:#222}.wp-block-wpzoom-recipe-card-block-details .detail-item-label{font-weight:bold;margin-bottom:0;display:block}.wp-block-wpzoom-recipe-card-block-details .detail-item-value{font-weight:500;margin-bottom:0;margin-right:5px;font-size:15px;display:inline-block;line-height:1.4em}.wp-block-wpzoom-recipe-card-block-details .detail-item{float:left;margin-bottom:15px;position:relative;line-height:1.4em}.wp-block-wpzoom-recipe-card-block-details .detail-item::after{content:'';position:absolute;width:1px;right:0;top:0;bottom:0;background-color:#ededed}.wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item{width:40%;margin-right:10%;padding-right:8%}.wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-1,.wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-3,.wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-5,.wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-7,.wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-9,.wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-11{margin-right:0;padding-right:0}.wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-1::after,.wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-3::after,.wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-5::after,.wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-7::after,.wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-9::after,.wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-11::after{display:none}.wp-block-wpzoom-recipe-card-block-details.col-3 .detail-item,.wp-block-wpzoom-recipe-card-block-details.col-5 .detail-item,.wp-block-wpzoom-recipe-card-block-details.col-6 .detail-item,.wp-block-wpzoom-recipe-card-block-details.col-7 .detail-item,.wp-block-wpzoom-recipe-card-block-details.col-9 .detail-item,.wp-block-wpzoom-recipe-card-block-details.col-10 .detail-item,.wp-block-wpzoom-recipe-card-block-details.col-11 .detail-item{width:30%;margin-right:5%;padding-right:5%}.wp-block-wpzoom-recipe-card-block-details.col-3 .detail-item-2,.wp-block-wpzoom-recipe-card-block-details.col-3 .detail-item-5,.wp-block-wpzoom-recipe-card-block-details.col-3 .detail-item-8,.wp-block-wpzoom-recipe-card-block-details.col-3 .detail-item-11,.wp-block-wpzoom-recipe-card-block-details.col-5 .detail-item-2,.wp-block-wpzoom-recipe-card-block-details.col-6 .detail-item-2,.wp-block-wpzoom-recipe-card-block-details.col-6 .detail-item-5,.wp-block-wpzoom-recipe-card-block-details.col-7 .detail-item-2,.wp-block-wpzoom-recipe-card-block-details.col-7 .detail-item-5,.wp-block-wpzoom-recipe-card-block-details.col-9 .detail-item-2,.wp-block-wpzoom-recipe-card-block-details.col-9 .detail-item-5,.wp-block-wpzoom-recipe-card-block-details.col-9 .detail-item-8,.wp-block-wpzoom-recipe-card-block-details.col-10 .detail-item-2,.wp-block-wpzoom-recipe-card-block-details.col-10 .detail-item-5,.wp-block-wpzoom-recipe-card-block-details.col-10 .detail-item-8,.wp-block-wpzoom-recipe-card-block-details.col-11 .detail-item-2,.wp-block-wpzoom-recipe-card-block-details.col-11 .detail-item-5,.wp-block-wpzoom-recipe-card-block-details.col-11 .detail-item-8{margin-right:0;padding-right:0}.wp-block-wpzoom-recipe-card-block-details.col-3 .detail-item-2::after,.wp-block-wpzoom-recipe-card-block-details.col-3 .detail-item-5::after,.wp-block-wpzoom-recipe-card-block-details.col-3 .detail-item-8::after,.wp-block-wpzoom-recipe-card-block-details.col-3 .detail-item-11::after,.wp-block-wpzoom-recipe-card-block-details.col-5 .detail-item-2::after,.wp-block-wpzoom-recipe-card-block-details.col-6 .detail-item-2::after,.wp-block-wpzoom-recipe-card-block-details.col-6 .detail-item-5::after,.wp-block-wpzoom-recipe-card-block-details.col-7 .detail-item-2::after,.wp-block-wpzoom-recipe-card-block-details.col-7 .detail-item-5::after,.wp-block-wpzoom-recipe-card-block-details.col-9 .detail-item-2::after,.wp-block-wpzoom-recipe-card-block-details.col-9 .detail-item-5::after,.wp-block-wpzoom-recipe-card-block-details.col-9 .detail-item-8::after,.wp-block-wpzoom-recipe-card-block-details.col-10 .detail-item-2::after,.wp-block-wpzoom-recipe-card-block-details.col-10 .detail-item-5::after,.wp-block-wpzoom-recipe-card-block-details.col-10 .detail-item-8::after,.wp-block-wpzoom-recipe-card-block-details.col-11 .detail-item-2::after,.wp-block-wpzoom-recipe-card-block-details.col-11 .detail-item-5::after,.wp-block-wpzoom-recipe-card-block-details.col-11 .detail-item-8::after{display:none}.wp-block-wpzoom-recipe-card-block-details.col-4 .detail-item,.wp-block-wpzoom-recipe-card-block-details.col-8 .detail-item,.wp-block-wpzoom-recipe-card-block-details.col-12 .detail-item{width:22%;margin-right:4%;padding-right:3%}.wp-block-wpzoom-recipe-card-block-details.col-4 .detail-item-3,.wp-block-wpzoom-recipe-card-block-details.col-4 .detail-item-7,.wp-block-wpzoom-recipe-card-block-details.col-4 .detail-item-11,.wp-block-wpzoom-recipe-card-block-details.col-8 .detail-item-3,.wp-block-wpzoom-recipe-card-block-details.col-8 .detail-item-7,.wp-block-wpzoom-recipe-card-block-details.col-12 .detail-item-3,.wp-block-wpzoom-recipe-card-block-details.col-12 .detail-item-7,.wp-block-wpzoom-recipe-card-block-details.col-12 .detail-item-11{margin-right:0;padding-right:0}.wp-block-wpzoom-recipe-card-block-details.col-4 .detail-item-3::after,.wp-block-wpzoom-recipe-card-block-details.col-4 .detail-item-7::after,.wp-block-wpzoom-recipe-card-block-details.col-4 .detail-item-11::after,.wp-block-wpzoom-recipe-card-block-details.col-8 .detail-item-3::after,.wp-block-wpzoom-recipe-card-block-details.col-8 .detail-item-7::after,.wp-block-wpzoom-recipe-card-block-details.col-12 .detail-item-3::after,.wp-block-wpzoom-recipe-card-block-details.col-12 .detail-item-7::after,.wp-block-wpzoom-recipe-card-block-details.col-12 .detail-item-11::after{display:none}@media screen and (max-width: 768px){.wp-block-wpzoom-recipe-card-block-details .details-items .detail-item{width:46%}}
-:root{--wp-admin-theme-color: #007cba;--wp-admin-theme-color-darker-10: #006ba1;--wp-admin-theme-color-darker-20: #005a87}html[amp] *,html[amp] *:before,html[amp] *:after{-webkit-box-sizing:border-box;box-sizing:border-box}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link{display:none}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit{right:20px}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit{margin-right:0}.wp-block-wpzoom-recipe-card-block-directions{position:relative;margin:0 0 20px;padding:30px 0 15px;text-align:left;max-width:750px}.wp-block-wpzoom-recipe-card-block-directions .wpzoom-recipe-card-print-link{position:absolute;right:30px;top:30px;text-align:right;z-index:1}.wp-block-wpzoom-recipe-card-block-directions .wpzoom-recipe-card-print-link a{display:inline-block;text-decoration:none;color:#a0a0a0}.wp-block-wpzoom-recipe-card-block-directions .wpzoom-recipe-card-print-link .icon-print-link{display:inline-block;vertical-align:text-top;width:18px;margin-right:5px}.wp-block-wpzoom-recipe-card-block-directions .wpzoom-recipe-card-print-link.hidden{display:none}.wp-block-wpzoom-recipe-card-block-directions .wpzoom-recipe-card-print-link.visible{display:block}.wp-block-wpzoom-recipe-card-block-directions .directions-title{font-size:22px;font-weight:600;color:inherit;margin:0 0 20px;padding:0;background-color:transparent;font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"}.wp-block-wpzoom-recipe-card-block-directions .directions-list{counter-reset:count;line-height:normal;list-style:none;margin:0}.wp-block-wpzoom-recipe-card-block-directions .directions-list>li{position:relative;line-height:1.8;list-style:none;min-height:44px;padding-left:40px;margin:0 0 15px}.wp-block-wpzoom-recipe-card-block-directions .directions-list>li::before{counter-increment:count;content:counter(count);display:block;position:absolute;top:0;left:0;font-size:24px;font-weight:bold;text-transform:uppercase;line-height:1.4;color:#222;background:none;width:35px;vertical-align:middle;padding:0;margin-right:20px}.wp-block-wpzoom-recipe-card-block-directions .directions-list>li:last-child{margin:0}.wp-block-wpzoom-recipe-card-block-directions .directions-list .direction-step-group::before{content:'';counter-increment:none}.wp-block-wpzoom-recipe-card-block-directions .direction-step img{margin:10px 0;max-width:100%;height:auto;display:block}
-:root{--wp-admin-theme-color: #007cba;--wp-admin-theme-color-darker-10: #006ba1;--wp-admin-theme-color-darker-20: #005a87}html[amp] *,html[amp] *:before,html[amp] *:after{-webkit-box-sizing:border-box;box-sizing:border-box}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link{display:none}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit{right:20px}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit{margin-right:0}.wp-block-wpzoom-recipe-card-block-ingredients{position:relative;color:#736458;background-color:#FBF9E7;border-radius:3px;margin:0 0 20px;padding:30px;text-align:left;max-width:750px}.wp-block-wpzoom-recipe-card-block-ingredients .wpzoom-recipe-card-print-link{position:absolute;right:30px;top:30px;text-align:right;z-index:1}.wp-block-wpzoom-recipe-card-block-ingredients .wpzoom-recipe-card-print-link a{display:inline-block;text-decoration:none;color:#a0a0a0}.wp-block-wpzoom-recipe-card-block-ingredients .wpzoom-recipe-card-print-link .icon-print-link{display:inline-block;vertical-align:text-top;width:18px;margin-right:5px}.wp-block-wpzoom-recipe-card-block-ingredients .wpzoom-recipe-card-print-link.hidden{display:none}.wp-block-wpzoom-recipe-card-block-ingredients .wpzoom-recipe-card-print-link.visible{display:block}.wp-block-wpzoom-recipe-card-block-ingredients .ingredients-title{font-size:22px;font-weight:600;color:inherit;margin:0 0 20px;padding:0;background-color:transparent;font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"}.wp-block-wpzoom-recipe-card-block-ingredients .ingredients-list{margin:0 !important;padding:0 !important;list-style:none}.wp-block-wpzoom-recipe-card-block-ingredients .ingredients-list>li{list-style:none;padding:0 0 13px;margin:0 0 13px;border-bottom:1px solid #e9e5c9;position:relative;cursor:pointer;line-height:1.7}.wp-block-wpzoom-recipe-card-block-ingredients .ingredients-list>li .ingredient-item-name{display:inline-block;margin:0;vertical-align:middle}.wp-block-wpzoom-recipe-card-block-ingredients .ingredients-list>li .ingredient-item-name.is-strikethrough-active:hover{text-decoration:line-through}.wp-block-wpzoom-recipe-card-block-ingredients .ingredients-list>li::before{content:'';display:inline-block;vertical-align:middle;width:18px;height:18px;margin:0 10px 0 0;border-radius:50%;border:2px solid #DEDAB6;cursor:pointer;position:relative}.wp-block-wpzoom-recipe-card-block-ingredients .ingredients-list>li.ingredient-item-group{cursor:initial}.wp-block-wpzoom-recipe-card-block-ingredients .ingredients-list>li.ingredient-item-group::before{display:none}.wp-block-wpzoom-recipe-card-block-ingredients .ingredients-list>li.ticked .ingredient-item-name.is-strikethrough-active{text-decoration:line-through}.wp-block-wpzoom-recipe-card-block-ingredients .ingredients-list>li.ticked::before{border:2px solid #9AD093;background:#9AD093;-webkit-box-shadow:inset 0px 0px 0px 2px #FBF9E7;box-shadow:inset 0px 0px 0px 2px #FBF9E7}
-:root{--wp-admin-theme-color: #007cba;--wp-admin-theme-color-darker-10: #006ba1;--wp-admin-theme-color-darker-20: #005a87}html[amp] *,html[amp] *:before,html[amp] *:after{-webkit-box-sizing:border-box;box-sizing:border-box}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link{display:none}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit{right:20px}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit{margin-right:0}
-:root{--wp-admin-theme-color: #007cba;--wp-admin-theme-color-darker-10: #006ba1;--wp-admin-theme-color-darker-20: #005a87}html[amp] *,html[amp] *:before,html[amp] *:after{-webkit-box-sizing:border-box;box-sizing:border-box}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link{display:none}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit{right:20px}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit{margin-right:0}.custom-toast-container{position:fixed;top:20px;right:20px;z-index:9999}.custom-toast{background-color:#333;color:#fff;padding:12px 20px;border-radius:4px;margin-bottom:10px;-webkit-box-shadow:0 0 10px rgba(0,0,0,0.2);box-shadow:0 0 10px rgba(0,0,0,0.2);-webkit-transition:opacity 0.3s ease;-o-transition:opacity 0.3s ease;transition:opacity 0.3s ease}.custom-toast--success{background-color:#28a745 !important}.custom-toast--error{background-color:#dc3545 !important}.custom-toast--insufficient-credit{background-color:#dc3545 !important}
-:root{--wp-admin-theme-color: #007cba;--wp-admin-theme-color-darker-10: #006ba1;--wp-admin-theme-color-darker-20: #005a87}html[amp] *,html[amp] *:before,html[amp] *:after{-webkit-box-sizing:border-box;box-sizing:border-box}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link{display:none}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit{right:20px}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit{margin-right:0}#wpadminbar #wp-admin-bar-edit-wpzoom-recipe>.ab-item:before{content:url("data:image/svg+xml,%3Csvg version='1.1' xmlns='http://www.w3.org/2000/svg' width='20' height='20' style='fill:%2382878c' viewBox='0 0 32 32'%3E%3Ctitle%3Erecipe-cards%3C/title%3E%3Cpath d='M16.256 1.903c-2.895 0-5.457 1.653-6.813 4.277-3.598 0.031-6.38 3.186-6.38 6.994 0 2.715 1.454 5.154 3.679 6.297v8.467c0 0.873 0.659 1.629 1.53 1.629h15.495c0.872 0 1.53-0.756 1.53-1.629v-10.578c2.219-1.147 3.672-3.585 3.672-6.293 0-3.826-2.876-6.99-6.47-6.99-0.321 0-0.642 0.026-0.96 0.079-1.423-1.438-3.302-2.251-5.282-2.251zM11.816 8.467c0.704-2.022 2.452-3.307 4.439-3.307 1.4 0 2.671 0.641 3.584 1.826 0.394 0.51 1.048 0.724 1.651 0.517 0.33-0.113 0.669-0.17 1.007-0.17 1.853 0 3.409 1.647 3.409 3.733 0 1.706-1.060 3.175-2.54 3.598-0.683 0.196-1.132 0.852-1.132 1.573v4.355h-12.433v-2.247c0-0.721-0.45-1.38-1.136-1.574-1.479-0.419-2.542-1.887-2.542-3.597 0-2.053 1.578-3.736 3.371-3.736 0.196 0 0.394 0.021 0.588 0.062l0 0c0.751 0.157 1.477-0.299 1.732-1.032zM9.802 26.308v-2.459h12.433v2.459h-12.433z'%3E%3C/path%3E%3C/svg%3E%0A");font-size:16px !important;top:2px}.wp-block-wpzoom-recipe-card-block-recipe-card{max-width:750px}.wp-block-wpzoom-recipe-card-block-recipe-card.recipe-card-noimage .recipe-card-image{display:none}.wp-block-wpzoom-recipe-card-block-recipe-card.header-content-align-left .recipe-card-heading{text-align:left}.wp-block-wpzoom-recipe-card-block-recipe-card.header-content-align-center .recipe-card-heading{text-align:center}.wp-block-wpzoom-recipe-card-block-recipe-card.header-content-align-right .recipe-card-heading{text-align:right}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-left,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-left,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-left{margin-right:auto}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-left .recipe-card-summary,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-left .recipe-card-ingredients,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-left .recipe-card-directions,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-left .recipe-card-video,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-left .recipe-card-notes,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-left .recipe-card-summary,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-left .recipe-card-ingredients,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-left .recipe-card-directions,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-left .recipe-card-video,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-left .recipe-card-notes,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-left .recipe-card-summary,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-left .recipe-card-ingredients,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-left .recipe-card-directions,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-left .recipe-card-video,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-left .recipe-card-notes{text-align:left}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-left .recipe-card-directions .directions-list>li img,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-left .recipe-card-directions .directions-list>li img,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-left .recipe-card-directions .directions-list>li img{margin-right:auto}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-center,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-center,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-center{margin-left:auto;margin-right:auto}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right{margin-left:auto}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-image figure figcaption,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-image figure figcaption,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-image figure figcaption{text-align:right}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-summary,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-ingredients,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-directions,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-video,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-notes,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-summary,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-ingredients,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-directions,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-video,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-notes,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-summary,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-ingredients,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-directions,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-video,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-notes{text-align:right}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-ingredients .ingredients-list>li .tick-circle,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-ingredients .ingredients-list>li .tick-circle,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-ingredients .ingredients-list>li .tick-circle{float:right;margin:6px 0 0 10px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-ingredients .ingredients-list .ingredient-item-name,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-ingredients .ingredients-list .ingredient-item-name,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-ingredients .ingredients-list .ingredient-item-name{padding-left:0;padding-right:30px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-directions .directions-list>li,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-directions .directions-list>li,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-directions .directions-list>li{padding-left:0;padding-right:40px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-directions .directions-list>li::before,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-directions .directions-list>li::before,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-directions .directions-list>li::before{left:auto;right:0;margin-right:0;margin-left:20px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-directions .directions-list>li img,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-directions .directions-list>li img,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-directions .directions-list>li img{margin-left:auto}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-notes .recipe-card-notes-list>li::before,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-notes .recipe-card-notes-list>li::before,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-notes .recipe-card-notes-list>li::before{left:auto;right:-6px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-center .recipe-card-image figure figcaption{text-align:left}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-left .recipe-card-image figure figcaption{text-align:left}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-heading .recipe-card-author{margin-bottom:10px}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-heading .recipe-card-title+p{margin-bottom:0}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-heading .wpzoom-recipe-card-print-link{display:inline-block;vertical-align:middle;float:right;border:1px dashed rgba(0,0,0,0.1);padding:5px}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-heading .wpzoom-recipe-card-print-link .btn-print-link{display:block;font-style:normal;text-decoration:none;font-size:14px;font-weight:600;line-height:1.2;color:#000;border:none;-webkit-box-shadow:none;box-shadow:none;-webkit-transition:.2s ease opacity;-o-transition:.2s ease opacity;transition:.2s ease opacity}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-heading .wpzoom-recipe-card-print-link .btn-print-link:hover{opacity:.8}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-heading .wpzoom-recipe-card-print-link .btn-print-link .wpzoom-rcb-icon-print-link{display:inline-block;width:22px;height:22px;vertical-align:middle;fill:#000}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-heading .wpzoom-recipe-card-print-link .btn-print-link .wpzoom-rcb-print-icon{font-size:18px;margin-right:calc(6px);vertical-align:middle}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-heading .wpzoom-recipe-card-print-link .btn-print-link span{display:none}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-heading::after{content:'';clear:both;display:table}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image figure img{width:100%}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image figure figcaption{padding:0;margin:0}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link{margin-top:0;margin-bottom:0}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link{margin-top:0;margin-bottom:0}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-video{margin-top:20px;margin-bottom:20px}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-video video{max-width:100%}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-video blockquote{border:none;font-size:0}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-video blockquote *{display:none}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-video blockquote iframe{display:block}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-video [poster]{-o-object-fit:cover;object-fit:cover}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details{margin-bottom:15px;clear:both}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .detail-item{position:relative}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .detail-item>p:not(.detail-item-label):not(.detail-item-value):not(.detail-item-unit){display:none}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .detail-item .detail-item-label{margin-bottom:5px}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .detail-item .detail-item-unit{margin-bottom:0}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .detail-item .detail-item-input-wrapper{position:relative;display:-ms-inline-flexbox;display:inline-flex;-ms-flex-align:center;align-items:center}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .detail-item .wpzoom-info-icon{display:inline-block;margin-left:5px;cursor:help;vertical-align:text-bottom;position:relative}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .detail-item .wpzoom-info-icon:hover{opacity:0.8}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .detail-item .wpzoom-info-icon svg{width:12px;height:12px;-webkit-filter:drop-shadow(0px 1px 1px rgba(0,0,0,0.1));filter:drop-shadow(0px 1px 1px rgba(0,0,0,0.1));vertical-align:middle}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .detail-item .components-tooltip{position:absolute !important;bottom:100% !important;left:50% !important;-webkit-transform:translateX(-50%) translateY(-4px) !important;-ms-transform:translateX(-50%) translateY(-4px) !important;transform:translateX(-50%) translateY(-4px) !important;background:#333 !important;color:white !important;padding:8px 12px !important;border-radius:4px !important;font-size:13px !important;white-space:nowrap !important;-webkit-box-shadow:0 2px 4px rgba(0,0,0,0.2) !important;box-shadow:0 2px 4px rgba(0,0,0,0.2) !important;z-index:9999 !important}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .detail-item .components-tooltip::before{content:'' !important;position:absolute !important;bottom:-4px !important;left:50% !important;-webkit-transform:translateX(-50%) !important;-ms-transform:translateX(-50%) !important;transform:translateX(-50%) !important;width:0 !important;height:0 !important;border-left:5px solid transparent !important;border-right:5px solid transparent !important;border-top:5px solid #333 !important}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-ingredients .ingredients-list{margin:0;padding:0}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-ingredients .ingredients-list>li{padding-left:0}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-ingredients .ingredients-list .ingredient-item-name{padding-left:30px;margin:0;vertical-align:middle}.wp-block-wpzoom-recipe-card-block-recipe-card .hidden{display:none !important}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-directions+.footer-copyright{margin-top:30px}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-directions .directions-list .direction-step-group{counter-reset:count}.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-directions .directions-list .direction-step-group::before{content:'';counter-increment:none}.wp-block-wpzoom-recipe-card-block-recipe-card .direction-step img{display:block;clear:both}.wp-block-wpzoom-recipe-card-block-recipe-card .footer-copyright p{margin-bottom:0;text-align:center;font-size:12px;letter-spacing:1px;text-transform:uppercase;color:#ababab}.wp-block-wpzoom-recipe-card-block-recipe-card .footer-copyright p a{color:#222222;text-decoration:none;padding-bottom:2px;border-bottom:1px solid #eee}.wp-block-wpzoom-recipe-card-block-recipe-card .footer-copyright p a:hover{text-decoration:none;border-bottom-color:#ccc}.wpzoom-recipe-card-buttons{text-align:center}.wpzoom-recipe-snippet-button.wp-block-wpzoom-recipe-card-block-print-recipe,.wpzoom-recipe-snippet-button.wp-block-wpzoom-recipe-card-block-jump-to-recipe,.wpzoom-recipe-card-buttons a.wpzoom-recipe-snippet-button{display:inline-block;border-radius:3px;padding:10px 20px;font-style:normal;text-decoration:none;font-size:14px;color:#fff;line-height:1.2;background-color:#041728;border:none;-webkit-box-shadow:none;box-shadow:none;margin-right:10px;margin-bottom:15px;font-weight:600}.wpzoom-recipe-snippet-button.wp-block-wpzoom-recipe-card-block-print-recipe:hover,.wpzoom-recipe-snippet-button.wp-block-wpzoom-recipe-card-block-jump-to-recipe:hover,.wpzoom-recipe-card-buttons a.wpzoom-recipe-snippet-button:hover{color:#fff;background-color:#0e2e4b}.wpzoom-recipe-snippet-button.wp-block-wpzoom-recipe-card-block-print-recipe svg,.wpzoom-recipe-snippet-button.wp-block-wpzoom-recipe-card-block-jump-to-recipe svg,.wpzoom-recipe-card-buttons a.wpzoom-recipe-snippet-button svg{display:inline-block;margin-right:6px;width:16px;height:16px;vertical-align:middle;fill:#fff}@media screen and (max-width: 600px){.wpzoom-recipe-snippet-button.wp-block-wpzoom-recipe-card-block-print-recipe,.wpzoom-recipe-snippet-button.wp-block-wpzoom-recipe-card-block-jump-to-recipe,.wpzoom-recipe-card-buttons a.wpzoom-recipe-snippet-button{padding:10px 15px}}@media screen and (max-width: 360px){.wpzoom-recipe-snippet-button.wp-block-wpzoom-recipe-card-block-print-recipe,.wpzoom-recipe-snippet-button.wp-block-wpzoom-recipe-card-block-jump-to-recipe,.wpzoom-recipe-card-buttons a.wpzoom-recipe-snippet-button{padding:10px}}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default{padding:20px 25px 30px;margin-top:50px;margin-bottom:50px;background:#ffffff;border:1px solid rgba(0,0,0,0.1);-webkit-box-shadow:0 0px 15px rgba(0,0,0,0.1);box-shadow:0 0px 15px rgba(0,0,0,0.1);border-radius:5px 5px 0 0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image{margin-top:-21px;margin-left:-26px;margin-right:-26px;margin-bottom:20px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image figure{position:relative;margin:0;line-height:0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image figure img{max-width:100%;width:100%;height:auto;margin:0;border-radius:5px 5px 0 0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image figure::before{content:'';position:absolute;width:100%;height:100%;top:0;left:0;z-index:1;background:-webkit-gradient(linear, left bottom, left top, from(rgba(0,0,0,0.65)), color-stop(35%, rgba(0,0,0,0)));background:-webkit-linear-gradient(bottom, rgba(0,0,0,0.65) 0%, rgba(0,0,0,0) 35%);background:-o-linear-gradient(bottom, rgba(0,0,0,0.65) 0%, rgba(0,0,0,0) 35%);background:linear-gradient(to top, rgba(0,0,0,0.65) 0%, rgba(0,0,0,0) 35%)}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image figure figcaption{position:absolute;right:20px;left:20px;text-align:right;bottom:8px;padding-bottom:10px;z-index:2;line-height:1.8}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-print-link{display:inline-block;vertical-align:middle}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link{display:block;border-radius:4px;padding:10px 20px;font-style:normal;text-decoration:none;font-size:14px;font-weight:600;line-height:1.2;color:#fff;background-color:#222;border:none;-webkit-box-shadow:none;box-shadow:none;-webkit-transition:.2s ease opacity;-o-transition:.2s ease opacity;transition:.2s ease opacity}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link:hover{opacity:.8}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link .wpzoom-rcb-icon-print-link{display:inline-block;margin-right:8px;width:16px;height:16px;vertical-align:middle;fill:#fff}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link .wpzoom-rcb-print-icon{font-size:18px;margin-right:calc(6px);vertical-align:middle}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link .wpzoom-rcb-print-icon+span{font-size:14px;vertical-align:middle}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-pinit{display:inline-block;vertical-align:middle;margin-right:10px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link{cursor:pointer;display:block;border-radius:4px;padding:10px 20px;text-decoration:none;font-size:14px;font-weight:600;color:#fff;line-height:1.2;border:none;-webkit-box-shadow:none;box-shadow:none;background-color:#C62122;-webkit-transition:.2s ease opacity;-o-transition:.2s ease opacity;transition:.2s ease opacity}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link:hover{opacity:.8}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link .wpzoom-rcb-icon-pinit-link{display:inline-block;margin-right:8px;width:16px;height:16px;vertical-align:middle;fill:#fff}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link .wpzoom-rcb-pinit-icon{font-size:18px;margin-right:calc(6px);vertical-align:middle}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link .wpzoom-rcb-pinit-icon+span{font-size:14px;vertical-align:middle}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-heading{margin-bottom:15px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-heading .recipe-card-title{font-size:30px;font-weight:600;font-family:inherit;margin:0 0 10px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-heading .recipe-card-author{display:block;color:#5b5d61;font-size:14px;font-weight:normal;font-style:italic;margin:0 0 12px;padding:0 0 12px;border-bottom:1px dashed rgba(0,0,0,0.1)}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-heading .recipe-card-course,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-heading .recipe-card-cuisine,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-heading .recipe-card-difficulty{font-size:14px;color:#5b5d61}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-heading .recipe-card-course mark,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-heading .recipe-card-cuisine mark,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-heading .recipe-card-difficulty mark{color:#222;font-weight:600;background:transparent;padding:0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-heading span:not(.recipe-card-author)+span:not(.recipe-card-author):before{content:" / ";color:#B6BABB;margin:0 12px;font-style:normal;opacity:.5}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items{font-size:0;border-left:1px dashed rgba(0,0,0,0.1);border-top:1px dashed rgba(0,0,0,0.1);text-align:center;display:-ms-flexbox;display:flex;-ms-flex-wrap:wrap;flex-wrap:wrap}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item{-ms-flex:1 0 25%;flex:1 0 25%;padding:10px 1.5%;position:relative;-webkit-box-sizing:border-box;box-sizing:border-box;border-right:1px dashed rgba(0,0,0,0.1);border-bottom:1px dashed rgba(0,0,0,0.1)}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-label{font-weight:bold}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-label,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-value,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-unit{font-size:14px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-icon,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-label{display:block}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-value{font-weight:500;margin:0 5px 0 0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-value,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-unit{display:inline-block;line-height:1.4}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-icon{opacity:.7;margin:0 auto;height:35px;line-height:35px;font-size:16px;color:#6d767f}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-icon .components-icon-button{margin:0 auto !important}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-icon span{color:#6d767f}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-icon span::before{font-size:16px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-icon svg{fill:#6d767f}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-summary{margin-bottom:20px !important;font-size:14px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .ingredients-title{font-size:22px;font-weight:600;color:#222;margin:0 0 20px;padding:0;background-color:transparent;font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .directions-title{font-size:22px;font-weight:600;color:#222;margin:0 0 20px;padding:0;background-color:transparent;font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .video-title{font-size:22px;font-weight:600;color:#222;margin:0 0 20px;padding:0;background-color:transparent;font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .notes-title{font-size:22px;font-weight:600;color:#222;margin:0 0 20px;padding:0;background-color:transparent;font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .directions-title{margin-bottom:25px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-ingredients{position:relative;color:#736458;background-color:#FBF9E7;border-radius:3px;margin:0 0 30px;padding:25px 25px 5px;text-align:left}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .ingredients-list{margin:0;padding:0;list-style:none}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .ingredients-list>li{list-style:none;padding:0 0 13px;margin:0 0 13px;border-bottom:1px solid #e9e5c9;position:relative;line-height:1.7}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .ingredients-list>li.ingredient-item-group{cursor:initial}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .ingredients-list>li:last-child{border-bottom:none}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .ingredients-list>li::after{content:'';clear:both;display:table}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .ingredients-list>li .tick-circle{content:'';float:left;width:18px;height:18px;margin:6px 10px 0 0;border-radius:50%;border:2px solid #DEDAB6;cursor:pointer;position:relative}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .ingredients-list>li.ticked .ingredient-item-name.is-strikethrough-active{text-decoration:line-through}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .ingredients-list>li.ticked .tick-circle{border:2px solid #9AD093 !important;background:#9AD093;-webkit-box-shadow:inset 0px 0px 0px 2px #fff;box-shadow:inset 0px 0px 0px 2px #fff}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .directions-list{counter-reset:count;line-height:normal;list-style:none;margin:0;padding:0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .directions-list>li{position:relative;line-height:1.8;list-style:none;padding-left:40px;margin:0 0 15px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .directions-list>li::before{counter-increment:count;content:counter(count);display:block;position:absolute;top:0;left:0;font-size:24px;font-weight:bold;text-transform:uppercase;line-height:1.4;color:#222;background:none;width:35px;vertical-align:middle;padding:0;margin-right:20px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .directions-list>li:last-child{margin:0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .directions-list>li .direction-step-text{margin-bottom:20px;font-size:14px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .directions-list>li .direction-step-text img{max-width:100%;height:auto;display:block}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .directions-list>li:last-child .direction-step-text{margin-bottom:0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .direction-step img{margin:10px 0;max-width:100%;height:auto;display:block}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-notes{margin-top:30px;padding-top:20px;border-top:1px dashed rgba(0,0,0,0.1);margin-bottom:30px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-notes .recipe-card-notes-list,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-notes ul{margin:0;padding:0;list-style:none}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-notes .recipe-card-notes-list>li:empty,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-notes ul>li:empty{display:none}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-notes .recipe-card-notes-list>li,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-notes ul>li{position:relative;background-color:#FBF9E7;color:#736458;margin:0 0 15px;padding:20px 25px 20px 50px;list-style-type:none;font-size:14px;border-radius:5px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-notes .recipe-card-notes-list>li::before,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-notes ul>li::before{content:"i";position:absolute;display:block;color:#fff;background-color:#222;border-radius:8px;width:16px;height:16px;line-height:16px;font-size:12px;text-align:center;left:14px;top:50%;-webkit-transform:translateY(-50%);-ms-transform:translateY(-50%);transform:translateY(-50%)}@media screen and (max-width: 700px){.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image{margin-bottom:15px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-heading .recipe-card-title{font-size:24px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items{-ms-flex-wrap:wrap;flex-wrap:wrap}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item{min-width:50%;padding:7px 1.5%;border-bottom:1px dashed rgba(0,0,0,0.1)}}@media screen and (max-width: 460px){.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-icon{display:none}}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign{padding:20px 30px 35px;margin-top:50px;margin-bottom:50px;background:#ffffff;border:1px solid rgba(0,0,0,0.1);-webkit-box-shadow:0 0px 15px rgba(0,0,0,0.1);box-shadow:0 0px 15px rgba(0,0,0,0.1);border-radius:5px 5px 0 0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image{margin-top:-21px;margin-left:-31px;margin-right:-31px;margin-bottom:30px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image figure{position:relative;margin:0;line-height:0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image figure img{max-width:100%;width:100%;height:auto;margin:0;border-radius:5px 5px 0 0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-print-link{position:absolute;right:20px;bottom:-26px;z-index:2;line-height:1.8}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link{display:block;width:52px;height:52px;border-radius:50%;padding:10px 8px;text-align:center;text-decoration:none;font-size:12px;color:#fff;line-height:1.2;background-color:#FFA921;-webkit-box-shadow:0 5px 40px #FFA921;box-shadow:0 5px 40px #FFA921;border:none;-webkit-transition:.2s ease box-shadow;-o-transition:.2s ease box-shadow;transition:.2s ease box-shadow}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link:hover{opacity:.9;-webkit-box-shadow:0 15px 10px #FFA921;box-shadow:0 15px 10px #FFA921}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link .wpzoom-rcb-icon-print-link{margin:auto;margin-bottom:5px;display:block;width:16px;height:16px;fill:#fff}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link .wpzoom-rcb-print-icon{font-size:18px;margin-right:calc(6px);vertical-align:middle}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link .wpzoom-rcb-print-icon+span{font-size:14px;vertical-align:middle}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-pinit{position:absolute;right:90px;bottom:-26px;z-index:2;line-height:1.8}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link{cursor:pointer;display:block;width:52px;height:52px;border-radius:50%;padding:10px 8px;text-align:center;text-decoration:none;font-size:12px;color:#fff;line-height:1.2;background-color:#C62122;-webkit-box-shadow:0 5px 40px #C62122;box-shadow:0 5px 40px #C62122;outline:0;-webkit-transition:.2s ease box-shadow;-o-transition:.2s ease box-shadow;transition:.2s ease box-shadow}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link:hover{opacity:.8;-webkit-box-shadow:0 5px 30px #C62122;box-shadow:0 5px 30px #C62122}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link .wpzoom-rcb-icon-pinit-link{margin:auto;margin-bottom:5px;display:block;width:16px;height:16px;fill:#fff}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link .wpzoom-rcb-pinit-icon{font-size:18px;margin-right:calc(6px);vertical-align:middle}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link .wpzoom-rcb-pinit-icon+span{font-size:14px;vertical-align:middle}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-heading{margin-bottom:15px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-heading .recipe-card-title{font-size:30px;font-weight:600;font-family:inherit;margin:0 0 10px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-heading .recipe-card-author{display:block;color:#5b5d61;font-size:14px;font-weight:normal;font-style:italic;margin:0 0 15px;padding:0 0 15px;border-bottom:1px dashed rgba(0,0,0,0.1)}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-heading .recipe-card-course,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-heading .recipe-card-cuisine,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-heading .recipe-card-difficulty{font-size:14px;color:#5b5d61}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-heading .recipe-card-course mark,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-heading .recipe-card-cuisine mark,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-heading .recipe-card-difficulty mark{color:#222;font-weight:600;background:transparent;padding:0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-heading span:not(.recipe-card-author)+span:not(.recipe-card-author):before{content:" / ";color:#B6BABB;margin:0 12px;font-style:normal;opacity:.5}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items{font-size:0;border-left:1px dashed rgba(0,0,0,0.1);border-top:1px dashed rgba(0,0,0,0.1);text-align:center;display:-ms-flexbox;display:flex;-ms-flex-wrap:wrap;flex-wrap:wrap}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item{-ms-flex:1 0 25%;flex:1 0 25%;padding:10px 1.5%;position:relative;-webkit-box-sizing:border-box;box-sizing:border-box;border-right:1px dashed rgba(0,0,0,0.1);border-bottom:1px dashed rgba(0,0,0,0.1)}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-label{font-weight:bold}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-label,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-value,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-unit{font-size:14px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-icon,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-label{display:block}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-value{font-weight:500;margin-right:5px;margin-bottom:0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-value,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-unit{display:inline-block;line-height:1.4}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-icon{height:35px;line-height:35px;font-size:16px;margin:auto;color:#6d767f}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-icon span{color:#6d767f}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-icon span::before{font-size:16px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-icon svg{fill:#6d767f}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-icon .components-icon-button{margin:0 auto !important}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-summary{margin-bottom:20px !important}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-ingredients{margin:15px 0 30px;padding:25px 0;border-top:1px dashed rgba(0,0,0,0.1);border-bottom:1px dashed rgba(0,0,0,0.1);position:relative;text-align:left}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-title{font-size:22px;font-weight:600;color:#222;margin:0 0 20px;padding:0;background-color:transparent;font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .directions-title{font-size:22px;font-weight:600;color:#222;margin:0 0 20px;padding:0;background-color:transparent;font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .video-title{font-size:22px;font-weight:600;color:#222;margin:0 0 20px;padding:0;background-color:transparent;font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .notes-title{font-size:22px;font-weight:600;color:#222;margin:0 0 20px;padding:0;background-color:transparent;font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list{margin:0;padding:0;list-style:none}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list>li{list-style:none;margin:0 0 10px;position:relative;line-height:1.7}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list>li.ingredient-item-group{cursor:initial}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list>li::after{content:'';clear:both;display:table}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list>li .tick-circle{content:'';float:left;width:18px;height:18px;margin:6px 10px 0 0;border-radius:50%;border:2px solid #FFA921;cursor:pointer;position:relative}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list>li.ticked .ingredient-item-name.is-strikethrough-active{text-decoration:line-through}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list>li.ticked .tick-circle{border:2px solid #9AD093 !important;background:#9AD093;-webkit-box-shadow:inset 0px 0px 0px 2px #fff;box-shadow:inset 0px 0px 0px 2px #fff}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list.layout-2-columns{-webkit-columns:2;-moz-columns:2;columns:2}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list.layout-2-columns .ingredient-item-group{-webkit-column-span:all;-moz-column-span:all;column-span:all}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .directions-list{counter-reset:count;line-height:normal;list-style:none;margin:0;padding:0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .directions-list>li{position:relative;line-height:1.8;list-style:none;padding-left:40px;margin:0 0 15px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .directions-list>li::before{counter-increment:count;content:counter(count);display:block;position:absolute;top:0;left:0;font-size:24px;font-weight:bold;text-transform:uppercase;line-height:1.4;color:#222;background:none;width:35px;vertical-align:middle;padding:0;margin-right:20px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .directions-list>li:last-child{margin:0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .directions-list>li .direction-step-text{margin-bottom:20px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .directions-list>li .direction-step-text img{max-width:100%;height:auto;display:block}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .directions-list>li:last-child .direction-step-text{margin-bottom:0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .direction-step img{margin:10px 0;max-width:100%;height:auto;display:block}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-notes{margin-top:30px;margin-bottom:30px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-notes .recipe-card-notes-list,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-notes ul{margin:0;padding:0;list-style:none}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-notes .recipe-card-notes-list>li:empty,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-notes ul>li:empty{display:none}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-notes .recipe-card-notes-list>li,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-notes ul>li{position:relative;background-color:#f5f5f5;color:inherit;margin:0 0 15px;padding:20px 25px 20px 50px;list-style-type:none;font-size:14px;border-radius:5px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-notes .recipe-card-notes-list>li::before,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-notes ul>li::before{content:"i";position:absolute;display:block;color:#fff;background-color:#FFA921;border-radius:8px;width:16px;height:16px;line-height:16px;font-size:12px;text-align:center;left:14px;top:50%;-webkit-transform:translateY(-50%);-ms-transform:translateY(-50%);transform:translateY(-50%)}@media screen and (max-width: 700px){.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image{margin-bottom:15px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-heading .recipe-card-title{font-size:24px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item{min-width:50%;padding:7px 1.5%;border-bottom:1px dashed rgba(0,0,0,0.1)}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list.layout-2-columns{-webkit-columns:1;-moz-columns:1;columns:1}}@media screen and (max-width: 460px){.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-icon{display:none}}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple{padding:25px;border-radius:10px;margin-top:50px;margin-bottom:50px;background:#ffffff;border:1px solid rgba(0,0,0,0.1)}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-header-wrap{margin:-26px -26px 25px -26px;padding:25px;background-color:#FFF3E0;border-radius:10px 10px 0 0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-header-wrap::after{content:'';clear:both;display:table}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.header-content-align-right .recipe-card-image{float:right;text-align:right}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.header-content-align-right .recipe-card-along-image{float:left;text-align:right}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.header-content-align-right .recipe-card-heading,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.header-content-align-right .recipe-card-details{margin-right:20px;margin-left:0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.header-content-align-right .details-items .detail-item{margin-right:0;margin-left:15px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image{float:left;width:40%}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image figure{position:relative;margin:0;line-height:0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image figure img{max-width:100%;width:100%;height:auto;margin:0;border-radius:8px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image figure figcaption{margin-top:10px;line-height:1.8}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-pinit,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-print-link{display:inline-block;vertical-align:middle}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-pinit{margin-right:12px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link{display:block;border-radius:4px;padding:8px 16px;font-style:normal;text-decoration:none;font-size:14px;font-weight:600;color:#fff;line-height:1.4;border:none;-webkit-box-shadow:none;box-shadow:none;cursor:pointer;background-color:#C62122;-webkit-transition:.2s ease opacity;-o-transition:.2s ease opacity;transition:.2s ease opacity}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link:hover{opacity:.8}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link .wpzoom-rcb-icon-pinit-link{display:inline-block;margin-right:8px;width:16px;height:16px;vertical-align:middle;fill:#fff}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link .wpzoom-rcb-pinit-icon{font-size:18px;margin-right:calc(6px);vertical-align:middle}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link .wpzoom-rcb-pinit-icon+span{font-size:14px;vertical-align:middle}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link{display:block;border-radius:4px;padding:8px 16px;font-style:normal;text-decoration:none;font-size:14px;font-weight:600;color:#fff;line-height:1.4;border:none;-webkit-box-shadow:none;box-shadow:none;cursor:pointer;color:#fff;background-color:#222;-webkit-transition:.2s ease opacity;-o-transition:.2s ease opacity;transition:.2s ease opacity}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link:hover{opacity:.8}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link .wpzoom-rcb-icon-print-link{display:inline-block;margin-right:8px;width:16px;height:16px;vertical-align:middle;fill:#fff}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link .wpzoom-rcb-print-icon{font-size:18px;margin-right:calc(6px);vertical-align:middle}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link .wpzoom-rcb-print-icon+span{font-size:14px;vertical-align:middle}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-along-image{float:right;width:60%}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading{margin-bottom:5px;margin-left:20px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-title{font-size:24px;font-weight:600;font-family:inherit;margin:0 0 10px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-author{display:block;color:#5b5d61;font-size:14px;font-weight:normal;font-style:italic;margin:0 0 6px;padding:0 0 12px;border-bottom:1px dashed rgba(0,0,0,0.1)}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-course,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-cuisine,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-difficulty{font-size:14px;color:#5b5d61}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-course mark,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-cuisine mark,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-difficulty mark{color:#222;font-weight:600;background:transparent;padding:0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading span:not(.recipe-card-author)+span:not(.recipe-card-author):before{content:" / ";color:#B6BABB;margin:0 12px;font-style:normal;opacity:.5}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-course,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-cuisine,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-difficulty{font-size:14px;color:#5b5d61;display:inline-block;margin-bottom:5px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-course mark,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-cuisine mark,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-difficulty mark{color:#222;font-weight:600;background:transparent;padding:0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading span:not(.recipe-card-author)+span:not(.recipe-card-author):before{content:" / ";color:#B6BABB;margin:0 12px;font-style:normal;opacity:.5}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-details{margin-left:20px;margin-bottom:0;padding-top:5px;border-top:1px dashed rgba(0,0,0,0.1)}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item{color:#333;display:inline-block;vertical-align:middle;margin-right:15px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-label{font-weight:bold;margin-right:5px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-label,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-value,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-unit{font-size:14px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-icon,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-label{display:inline-block}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-value{font-weight:500;margin:0 5px 0 0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-value,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-unit{display:inline-block;line-height:1.4}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-icon{opacity:.7;margin:0;margin-right:10px;height:35px;line-height:35px;font-size:16px;color:#6d767f;display:inline-block}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-icon .components-icon-button{margin:0 auto !important}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-icon span{color:#6d767f}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-icon span::before{font-size:16px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-icon svg{fill:#6d767f}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-summary{margin-bottom:20px !important}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .ingredients-title{font-size:22px;font-weight:600;color:#222;margin:0 0 20px;padding:0;background-color:transparent;font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .directions-title{font-size:22px;font-weight:600;color:#222;margin:0 0 20px;padding:0;background-color:transparent;font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .video-title{font-size:22px;font-weight:600;color:#222;margin:0 0 20px;padding:0;background-color:transparent;font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .notes-title{font-size:22px;font-weight:600;color:#222;margin:0 0 20px;padding:0;background-color:transparent;font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .directions-title{margin-bottom:25px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-ingredients{position:relative;margin:0 0 30px;text-align:left}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .ingredients-list{margin:0;padding:0;list-style:none}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .ingredients-list>li{list-style:none;margin:0 0 13px;position:relative;line-height:1.6}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .ingredients-list>li.ingredient-item-group{cursor:initial}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .ingredients-list>li:last-child{border-bottom:none}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .ingredients-list>li::after{content:'';clear:both;display:table}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .ingredients-list>li .tick-circle{content:'';float:left;width:18px;height:18px;margin:6px 10px 0 0;border-radius:50%;border:2px solid #d0d0d0;cursor:pointer;position:relative}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .ingredients-list>li.ticked .ingredient-item-name.is-strikethrough-active{text-decoration:line-through}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .ingredients-list>li.ticked .tick-circle{border:2px solid #9AD093 !important;background:#9AD093;-webkit-box-shadow:inset 0px 0px 0px 2px #fff;box-shadow:inset 0px 0px 0px 2px #fff}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .directions-list{counter-reset:count;line-height:normal;list-style:none;margin:0;padding:0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .directions-list>li{position:relative;line-height:1.8;list-style:none;padding-left:40px;margin:0 0 16px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .directions-list>li.direction-step-group{min-height:0;font-size:18px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .directions-list>li::before{counter-increment:count;content:counter(count);display:block;position:absolute;top:0;left:0;font-size:24px;font-weight:bold;text-transform:uppercase;line-height:1.4;color:#222;background:none;width:35px;vertical-align:middle;padding:0;margin-right:20px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .directions-list>li:last-child{margin:0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .directions-list>li .direction-step-text{margin-bottom:20px;font-size:14px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .directions-list>li .direction-step-text img{max-width:100%;height:auto;display:block}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .directions-list>li:last-child .direction-step-text{margin-bottom:0}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .direction-step img{margin:10px 0;max-width:100%;height:auto;display:block}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-notes{margin-top:30px;padding-top:20px;border-top:1px dashed rgba(0,0,0,0.1);margin-bottom:30px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-notes .recipe-card-notes-list,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-notes ul{margin:0;padding:0;list-style:none}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-notes .recipe-card-notes-list>li:empty,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-notes ul>li:empty{display:none}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-notes .recipe-card-notes-list>li,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-notes ul>li{position:relative;background-color:#FFF3E0;color:#736458;margin:0 0 15px;padding:20px 25px 20px 50px;list-style-type:none;font-size:14px;border-radius:5px}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-notes .recipe-card-notes-list>li::before,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-notes ul>li::before{content:"i";position:absolute;display:block;color:#fff;background-color:#222;border-radius:8px;width:16px;height:16px;line-height:16px;font-size:12px;text-align:center;left:14px;top:50%;-webkit-transform:translateY(-50%);-ms-transform:translateY(-50%);transform:translateY(-50%)}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.recipe-card-noimage .recipe-card-image-preview,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.recipe-card-noimage .recipe-card-image{display:none}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.recipe-card-noimage .recipe-card-along-image{float:none;width:100%}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.recipe-card-noimage .recipe-card-heading,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.recipe-card-noimage .recipe-card-details{margin-left:0}@media screen and (max-width: 768px){.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image{margin-bottom:15px;float:none;width:100%}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-along-image{float:none;width:100%}.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading,.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-details{margin-left:0}}
-:root{--wp-admin-theme-color: #007cba;--wp-admin-theme-color-darker-10: #006ba1;--wp-admin-theme-color-darker-20: #005a87}html[amp] *,html[amp] *:before,html[amp] *:after{-webkit-box-sizing:border-box;box-sizing:border-box}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link{display:none}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit{right:20px}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit{margin-right:0}#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition{font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;line-height:1.6;font-size:14px;border:1px solid #000;border-radius:0;padding:10px;margin:0 0 2em;color:#222}#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition h2{font-size:2.4em;line-height:1;letter-spacing:0;font-weight:800;padding:0 0 .4em;margin:0;border-bottom:1px solid #000;color:inherit}#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition p{margin:0;padding:0;font-size:1em;line-height:1.4em}#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition ul{list-style:none !important;margin:0;padding:0}#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition ul li{position:relative;margin:0;padding:0;border-top:1px solid #000;list-style-type:none}#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition ul li.nutrition-facts-no-border,#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition ul li:empty,#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition ul li:first-child{border:none}#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition ul li::after{content:'';clear:both;display:table}#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition ul ul{padding-left:0}#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition ul ul li{padding-left:20px}#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition strong{font-weight:700}#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition strong.nutrition-facts-label{font-weight:400}#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-heading{font-size:14px;font-weight:800}#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-right{float:right}#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-serving{font-size:1em}#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-serving-size{font-size:1.1em;font-weight:800}#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-serving-size+.nutrition-facts-label{font-size:1.1em;font-weight:800}#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-hr{border:none;border-top:1em solid;margin:.2em 0 0;padding:0;border-color:#000}#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-spacer{border:none;height:.5em;padding:0;background:#222}#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-amount-per-serving{display:block}#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-calories{font-weight:800;font-size:1.8em}#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-calories+.nutrition-facts-label{float:right;font-size:2.5em;line-height:1em;font-weight:800}#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-daily-value-text{line-height:1.2em;font-size:.75em;padding-top:5px;border-top:4px solid #000}#wpzoom-recipe-nutrition.layout-orientation-vertical .wp-block-wpzoom-recipe-card-block-nutrition{display:inline-block}#wpzoom-recipe-nutrition.layout-orientation-vertical .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-daily-value-text{max-width:300px}#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition::after{content:'';clear:both;display:table}#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-1,#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-2,#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-3{float:left;width:33.3333%;padding-right:10px}#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-3{padding-right:0}#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-1 .nutrition-facts-hr{border-top:1px solid #aaa;margin:.5em 0;background-color:transparent}#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-1 .nutrition-facts-hr+p{line-height:2em}#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-1 .nutrition-facts-calories{display:inline-block;margin-top:.3em}#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition ul>li.nutrition-facts-no-border:first-child{line-height:1em}#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition ul>li.nutrition-facts-no-border:first-child>strong{font-size:.75em}#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-amount-per-serving{display:inline-block}#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-bottom{clear:both;border-bottom:1px solid #aaa;padding-top:5px}#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-bottom li{border:none;display:inline-block;padding:0}#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-bottom li .nutrition-facts-right{float:none}#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-bottom li>strong{display:inline-block;vertical-align:middle}#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-bottom li::after{content:'\2022';display:inline-block;vertical-align:middle;margin:auto 10px}#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-bottom li:last-child::after{display:none}@media screen and (max-width: 600px){#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-1,#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-2,#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-3{float:none;width:100%;padding-right:0}#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-1 p{line-height:1.8em}#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-1 .nutrition-facts-hr{border:none;border-top:1em solid;margin:.2em 0 0;padding:0}#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-2>ul>.nutrition-facts-spacer{display:none}#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-3>ul>li:nth-child(1),#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-3>ul>li:nth-child(2){display:none}#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-3>ul>li:nth-child(3){border-top:1px solid #aaa}}
-:root{--wp-admin-theme-color: #007cba;--wp-admin-theme-color-darker-10: #006ba1;--wp-admin-theme-color-darker-20: #005a87}html[amp] *,html[amp] *:before,html[amp] *:after{-webkit-box-sizing:border-box;box-sizing:border-box}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link{display:none}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit{right:20px}html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit{margin-right:0}.wpzoom-custom-recipe-card-post>.wpzoom-recipe-card-buttons{display:none !important}
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * Colors
+ */
+/**
+ * Colors
+ */
+/**
+ * @style: Default
+*/
+/**
+ * @style: Newdesign
+*/
+/**
+ * @style: Simple
+*/
+/**
+ * Colors
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Grid System.
+ * https://make.wordpress.org/design/2019/10/31/proposal-a-consistent-spacing-system-for-wordpress/
+ */
+/**
+ * Dimensions.
+ */
+/**
+ * Shadows.
+ */
+/**
+ * Editor widths.
+ */
+/**
+ * Block UI.
+ */
+/**
+ * Border radii.
+ */
+/**
+ * Breakpoint mixins
+ */
+/**
+ * Long content fade mixin
+ *
+ * Creates a fading overlay to signify that the content is longer
+ * than the space allows.
+ */
+/**
+ * Focus styles.
+ */
+/**
+ * Applies editor left position to the selector passed as argument
+ */
+/**
+ * Styles that are reused verbatim in a few places
+ */
+/**
+ * Allows users to opt-out of animations via OS-level preferences.
+ */
+/**
+ * Reset default styles for JavaScript UI based pages.
+ * This is a WP-admin agnostic reset
+ */
+/**
+ * Reset the WP Admin page styles for Gutenberg-like pages.
+ */
+:root {
+  --wp-admin-theme-color: #007cba;
+  --wp-admin-theme-color-darker-10: #006ba1;
+  --wp-admin-theme-color-darker-20: #005a87; }
+
+/**
+ * Breakpoints & Media Queries
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Border radius.
+ */
+/**
+ * #.# Mixins SCSS
+ *
+ * Mixins allow you to define styles that can be re-used throughout your stylesheet.
+*/
+html[amp] *, html[amp] *:before, html[amp] *:after {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link {
+  display: none; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit {
+  right: 20px; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit {
+  margin-right: 0; }
+
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.wp-block-wpzoom-recipe-card-block-details {
+  position: relative;
+  margin: 0;
+  padding: 20px 0;
+  text-align: left;
+  max-width: 750px;
+  /*--------------------------------------------------------------
+    # 2 Columns
+    --------------------------------------------------------------*/
+  /*--------------------------------------------------------------
+    # 3, 5, 6, 7, 9, 10, 11 Columns
+    --------------------------------------------------------------*/
+  /*--------------------------------------------------------------
+    # 4, 8, 12 Columns
+    --------------------------------------------------------------*/ }
+  .wp-block-wpzoom-recipe-card-block-details .details-title {
+    font-size: 22px;
+    font-weight: 600;
+    color: inherit;
+    margin: 0 0 20px;
+    padding: 0;
+    background-color: transparent;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
+  .wp-block-wpzoom-recipe-card-block-details::after {
+    content: '';
+    clear: both;
+    display: table; }
+  .wp-block-wpzoom-recipe-card-block-details .details-items::after {
+    content: '';
+    clear: both;
+    display: table; }
+  .wp-block-wpzoom-recipe-card-block-details .detail-item-icon {
+    display: block; }
+    .wp-block-wpzoom-recipe-card-block-details .detail-item-icon::before {
+      color: #222222; }
+    .wp-block-wpzoom-recipe-card-block-details .detail-item-icon svg {
+      fill: #222222; }
+  .wp-block-wpzoom-recipe-card-block-details .detail-item-label {
+    font-weight: bold;
+    margin-bottom: 0;
+    display: block; }
+  .wp-block-wpzoom-recipe-card-block-details .detail-item-value {
+    font-weight: 500;
+    margin-bottom: 0;
+    margin-right: 5px;
+    font-size: 15px;
+    display: inline-block;
+    line-height: 1.4em; }
+  .wp-block-wpzoom-recipe-card-block-details .detail-item {
+    float: left;
+    margin-bottom: 15px;
+    position: relative;
+    line-height: 1.4em; }
+    .wp-block-wpzoom-recipe-card-block-details .detail-item::after {
+      content: '';
+      position: absolute;
+      width: 1px;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      background-color: #ededed; }
+  .wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item {
+    width: 40%;
+    margin-right: 10%;
+    padding-right: 8%; }
+  .wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-1, .wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-3, .wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-5, .wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-7,
+  .wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-9, .wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-11 {
+    margin-right: 0;
+    padding-right: 0; }
+    .wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-1::after, .wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-3::after, .wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-5::after, .wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-7::after,
+    .wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-9::after, .wp-block-wpzoom-recipe-card-block-details.col-2 .detail-item-11::after {
+      display: none; }
+  .wp-block-wpzoom-recipe-card-block-details.col-3 .detail-item,
+  .wp-block-wpzoom-recipe-card-block-details.col-5 .detail-item,
+  .wp-block-wpzoom-recipe-card-block-details.col-6 .detail-item,
+  .wp-block-wpzoom-recipe-card-block-details.col-7 .detail-item,
+  .wp-block-wpzoom-recipe-card-block-details.col-9 .detail-item,
+  .wp-block-wpzoom-recipe-card-block-details.col-10 .detail-item,
+  .wp-block-wpzoom-recipe-card-block-details.col-11 .detail-item {
+    width: 30%;
+    margin-right: 5%;
+    padding-right: 5%; }
+  .wp-block-wpzoom-recipe-card-block-details.col-3 .detail-item-2, .wp-block-wpzoom-recipe-card-block-details.col-3 .detail-item-5, .wp-block-wpzoom-recipe-card-block-details.col-3 .detail-item-8, .wp-block-wpzoom-recipe-card-block-details.col-3 .detail-item-11,
+  .wp-block-wpzoom-recipe-card-block-details.col-5 .detail-item-2,
+  .wp-block-wpzoom-recipe-card-block-details.col-6 .detail-item-2, .wp-block-wpzoom-recipe-card-block-details.col-6 .detail-item-5,
+  .wp-block-wpzoom-recipe-card-block-details.col-7 .detail-item-2, .wp-block-wpzoom-recipe-card-block-details.col-7 .detail-item-5,
+  .wp-block-wpzoom-recipe-card-block-details.col-9 .detail-item-2, .wp-block-wpzoom-recipe-card-block-details.col-9 .detail-item-5, .wp-block-wpzoom-recipe-card-block-details.col-9 .detail-item-8,
+  .wp-block-wpzoom-recipe-card-block-details.col-10 .detail-item-2, .wp-block-wpzoom-recipe-card-block-details.col-10 .detail-item-5, .wp-block-wpzoom-recipe-card-block-details.col-10 .detail-item-8,
+  .wp-block-wpzoom-recipe-card-block-details.col-11 .detail-item-2, .wp-block-wpzoom-recipe-card-block-details.col-11 .detail-item-5, .wp-block-wpzoom-recipe-card-block-details.col-11 .detail-item-8 {
+    margin-right: 0;
+    padding-right: 0; }
+    .wp-block-wpzoom-recipe-card-block-details.col-3 .detail-item-2::after, .wp-block-wpzoom-recipe-card-block-details.col-3 .detail-item-5::after, .wp-block-wpzoom-recipe-card-block-details.col-3 .detail-item-8::after, .wp-block-wpzoom-recipe-card-block-details.col-3 .detail-item-11::after,
+    .wp-block-wpzoom-recipe-card-block-details.col-5 .detail-item-2::after,
+    .wp-block-wpzoom-recipe-card-block-details.col-6 .detail-item-2::after, .wp-block-wpzoom-recipe-card-block-details.col-6 .detail-item-5::after,
+    .wp-block-wpzoom-recipe-card-block-details.col-7 .detail-item-2::after, .wp-block-wpzoom-recipe-card-block-details.col-7 .detail-item-5::after,
+    .wp-block-wpzoom-recipe-card-block-details.col-9 .detail-item-2::after, .wp-block-wpzoom-recipe-card-block-details.col-9 .detail-item-5::after, .wp-block-wpzoom-recipe-card-block-details.col-9 .detail-item-8::after,
+    .wp-block-wpzoom-recipe-card-block-details.col-10 .detail-item-2::after, .wp-block-wpzoom-recipe-card-block-details.col-10 .detail-item-5::after, .wp-block-wpzoom-recipe-card-block-details.col-10 .detail-item-8::after,
+    .wp-block-wpzoom-recipe-card-block-details.col-11 .detail-item-2::after, .wp-block-wpzoom-recipe-card-block-details.col-11 .detail-item-5::after, .wp-block-wpzoom-recipe-card-block-details.col-11 .detail-item-8::after {
+      display: none; }
+  .wp-block-wpzoom-recipe-card-block-details.col-4 .detail-item,
+  .wp-block-wpzoom-recipe-card-block-details.col-8 .detail-item,
+  .wp-block-wpzoom-recipe-card-block-details.col-12 .detail-item {
+    width: 22%;
+    margin-right: 4%;
+    padding-right: 3%; }
+  .wp-block-wpzoom-recipe-card-block-details.col-4 .detail-item-3, .wp-block-wpzoom-recipe-card-block-details.col-4 .detail-item-7, .wp-block-wpzoom-recipe-card-block-details.col-4 .detail-item-11,
+  .wp-block-wpzoom-recipe-card-block-details.col-8 .detail-item-3, .wp-block-wpzoom-recipe-card-block-details.col-8 .detail-item-7,
+  .wp-block-wpzoom-recipe-card-block-details.col-12 .detail-item-3, .wp-block-wpzoom-recipe-card-block-details.col-12 .detail-item-7, .wp-block-wpzoom-recipe-card-block-details.col-12 .detail-item-11 {
+    margin-right: 0;
+    padding-right: 0; }
+    .wp-block-wpzoom-recipe-card-block-details.col-4 .detail-item-3::after, .wp-block-wpzoom-recipe-card-block-details.col-4 .detail-item-7::after, .wp-block-wpzoom-recipe-card-block-details.col-4 .detail-item-11::after,
+    .wp-block-wpzoom-recipe-card-block-details.col-8 .detail-item-3::after, .wp-block-wpzoom-recipe-card-block-details.col-8 .detail-item-7::after,
+    .wp-block-wpzoom-recipe-card-block-details.col-12 .detail-item-3::after, .wp-block-wpzoom-recipe-card-block-details.col-12 .detail-item-7::after, .wp-block-wpzoom-recipe-card-block-details.col-12 .detail-item-11::after {
+      display: none; }
+
+@media screen and (max-width: 768px) {
+  .wp-block-wpzoom-recipe-card-block-details .details-items .detail-item {
+    width: 46%; } }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * Colors
+ */
+/**
+ * Colors
+ */
+/**
+ * @style: Default
+*/
+/**
+ * @style: Newdesign
+*/
+/**
+ * @style: Simple
+*/
+/**
+ * Colors
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Grid System.
+ * https://make.wordpress.org/design/2019/10/31/proposal-a-consistent-spacing-system-for-wordpress/
+ */
+/**
+ * Dimensions.
+ */
+/**
+ * Shadows.
+ */
+/**
+ * Editor widths.
+ */
+/**
+ * Block UI.
+ */
+/**
+ * Border radii.
+ */
+/**
+ * Breakpoint mixins
+ */
+/**
+ * Long content fade mixin
+ *
+ * Creates a fading overlay to signify that the content is longer
+ * than the space allows.
+ */
+/**
+ * Focus styles.
+ */
+/**
+ * Applies editor left position to the selector passed as argument
+ */
+/**
+ * Styles that are reused verbatim in a few places
+ */
+/**
+ * Allows users to opt-out of animations via OS-level preferences.
+ */
+/**
+ * Reset default styles for JavaScript UI based pages.
+ * This is a WP-admin agnostic reset
+ */
+/**
+ * Reset the WP Admin page styles for Gutenberg-like pages.
+ */
+:root {
+  --wp-admin-theme-color: #007cba;
+  --wp-admin-theme-color-darker-10: #006ba1;
+  --wp-admin-theme-color-darker-20: #005a87; }
+
+/**
+ * Breakpoints & Media Queries
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Border radius.
+ */
+/**
+ * #.# Mixins SCSS
+ *
+ * Mixins allow you to define styles that can be re-used throughout your stylesheet.
+*/
+html[amp] *, html[amp] *:before, html[amp] *:after {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link {
+  display: none; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit {
+  right: 20px; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit {
+  margin-right: 0; }
+
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.wp-block-wpzoom-recipe-card-block-directions {
+  position: relative;
+  margin: 0 0 20px;
+  padding: 30px 0 15px;
+  text-align: left;
+  max-width: 750px; }
+  .wp-block-wpzoom-recipe-card-block-directions .wpzoom-recipe-card-print-link {
+    position: absolute;
+    right: 30px;
+    top: 30px;
+    text-align: right;
+    z-index: 1; }
+    .wp-block-wpzoom-recipe-card-block-directions .wpzoom-recipe-card-print-link a {
+      display: inline-block;
+      text-decoration: none;
+      color: #a0a0a0; }
+    .wp-block-wpzoom-recipe-card-block-directions .wpzoom-recipe-card-print-link .icon-print-link {
+      display: inline-block;
+      vertical-align: text-top;
+      width: 18px;
+      margin-right: 5px; }
+    .wp-block-wpzoom-recipe-card-block-directions .wpzoom-recipe-card-print-link.hidden {
+      display: none; }
+    .wp-block-wpzoom-recipe-card-block-directions .wpzoom-recipe-card-print-link.visible {
+      display: block; }
+  .wp-block-wpzoom-recipe-card-block-directions .directions-title {
+    font-size: 22px;
+    font-weight: 600;
+    color: inherit;
+    margin: 0 0 20px;
+    padding: 0;
+    background-color: transparent;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
+  .wp-block-wpzoom-recipe-card-block-directions .directions-list {
+    counter-reset: count;
+    line-height: normal;
+    list-style: none;
+    margin: 0; }
+    .wp-block-wpzoom-recipe-card-block-directions .directions-list > li {
+      position: relative;
+      line-height: 1.8;
+      list-style: none;
+      min-height: 44px;
+      padding-left: 40px;
+      margin: 0 0 15px; }
+      .wp-block-wpzoom-recipe-card-block-directions .directions-list > li::before {
+        counter-increment: count;
+        content: counter(count);
+        display: block;
+        position: absolute;
+        top: 0;
+        left: 0;
+        font-size: 24px;
+        font-weight: bold;
+        text-transform: uppercase;
+        line-height: 1.4;
+        color: #222222;
+        background: none;
+        width: 35px;
+        vertical-align: middle;
+        padding: 0;
+        margin-right: 20px; }
+      .wp-block-wpzoom-recipe-card-block-directions .directions-list > li:last-child {
+        margin: 0; }
+    .wp-block-wpzoom-recipe-card-block-directions .directions-list .direction-step-group::before {
+      content: '';
+      counter-increment: none; }
+  .wp-block-wpzoom-recipe-card-block-directions .direction-step img {
+    margin: 10px 0;
+    max-width: 100%;
+    height: auto;
+    display: block; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * Colors
+ */
+/**
+ * Colors
+ */
+/**
+ * @style: Default
+*/
+/**
+ * @style: Newdesign
+*/
+/**
+ * @style: Simple
+*/
+/**
+ * Colors
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Grid System.
+ * https://make.wordpress.org/design/2019/10/31/proposal-a-consistent-spacing-system-for-wordpress/
+ */
+/**
+ * Dimensions.
+ */
+/**
+ * Shadows.
+ */
+/**
+ * Editor widths.
+ */
+/**
+ * Block UI.
+ */
+/**
+ * Border radii.
+ */
+/**
+ * Breakpoint mixins
+ */
+/**
+ * Long content fade mixin
+ *
+ * Creates a fading overlay to signify that the content is longer
+ * than the space allows.
+ */
+/**
+ * Focus styles.
+ */
+/**
+ * Applies editor left position to the selector passed as argument
+ */
+/**
+ * Styles that are reused verbatim in a few places
+ */
+/**
+ * Allows users to opt-out of animations via OS-level preferences.
+ */
+/**
+ * Reset default styles for JavaScript UI based pages.
+ * This is a WP-admin agnostic reset
+ */
+/**
+ * Reset the WP Admin page styles for Gutenberg-like pages.
+ */
+:root {
+  --wp-admin-theme-color: #007cba;
+  --wp-admin-theme-color-darker-10: #006ba1;
+  --wp-admin-theme-color-darker-20: #005a87; }
+
+/**
+ * Breakpoints & Media Queries
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Border radius.
+ */
+/**
+ * #.# Mixins SCSS
+ *
+ * Mixins allow you to define styles that can be re-used throughout your stylesheet.
+*/
+html[amp] *, html[amp] *:before, html[amp] *:after {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link {
+  display: none; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit {
+  right: 20px; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit {
+  margin-right: 0; }
+
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.wp-block-wpzoom-recipe-card-block-ingredients {
+  position: relative;
+  color: #736458;
+  background-color: #FBF9E7;
+  border-radius: 3px;
+  margin: 0 0 20px;
+  padding: 30px;
+  text-align: left;
+  max-width: 750px; }
+  .wp-block-wpzoom-recipe-card-block-ingredients .wpzoom-recipe-card-print-link {
+    position: absolute;
+    right: 30px;
+    top: 30px;
+    text-align: right;
+    z-index: 1; }
+    .wp-block-wpzoom-recipe-card-block-ingredients .wpzoom-recipe-card-print-link a {
+      display: inline-block;
+      text-decoration: none;
+      color: #a0a0a0; }
+    .wp-block-wpzoom-recipe-card-block-ingredients .wpzoom-recipe-card-print-link .icon-print-link {
+      display: inline-block;
+      vertical-align: text-top;
+      width: 18px;
+      margin-right: 5px; }
+    .wp-block-wpzoom-recipe-card-block-ingredients .wpzoom-recipe-card-print-link.hidden {
+      display: none; }
+    .wp-block-wpzoom-recipe-card-block-ingredients .wpzoom-recipe-card-print-link.visible {
+      display: block; }
+  .wp-block-wpzoom-recipe-card-block-ingredients .ingredients-title {
+    font-size: 22px;
+    font-weight: 600;
+    color: inherit;
+    margin: 0 0 20px;
+    padding: 0;
+    background-color: transparent;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
+  .wp-block-wpzoom-recipe-card-block-ingredients .ingredients-list {
+    margin: 0 !important;
+    padding: 0 !important;
+    list-style: none; }
+    .wp-block-wpzoom-recipe-card-block-ingredients .ingredients-list > li {
+      list-style: none;
+      padding: 0 0 13px;
+      margin: 0 0 13px;
+      border-bottom: 1px solid #e9e5c9;
+      position: relative;
+      cursor: pointer;
+      line-height: 1.7; }
+      .wp-block-wpzoom-recipe-card-block-ingredients .ingredients-list > li .ingredient-item-name {
+        display: inline-block;
+        margin: 0;
+        vertical-align: middle; }
+        .wp-block-wpzoom-recipe-card-block-ingredients .ingredients-list > li .ingredient-item-name.is-strikethrough-active:hover {
+          text-decoration: line-through; }
+      .wp-block-wpzoom-recipe-card-block-ingredients .ingredients-list > li::before {
+        content: '';
+        display: inline-block;
+        vertical-align: middle;
+        width: 18px;
+        height: 18px;
+        margin: 0 10px 0 0;
+        border-radius: 50%;
+        border: 2px solid #DEDAB6;
+        cursor: pointer;
+        position: relative; }
+      .wp-block-wpzoom-recipe-card-block-ingredients .ingredients-list > li.ingredient-item-group {
+        cursor: initial; }
+      .wp-block-wpzoom-recipe-card-block-ingredients .ingredients-list > li.ingredient-item-group::before {
+        display: none; }
+      .wp-block-wpzoom-recipe-card-block-ingredients .ingredients-list > li.ticked .ingredient-item-name.is-strikethrough-active {
+        text-decoration: line-through; }
+      .wp-block-wpzoom-recipe-card-block-ingredients .ingredients-list > li.ticked::before {
+        border: 2px solid #9AD093;
+        background: #9AD093;
+        -webkit-box-shadow: inset 0px 0px 0px 2px #FBF9E7;
+                box-shadow: inset 0px 0px 0px 2px #FBF9E7; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * Colors
+ */
+/**
+ * Colors
+ */
+/**
+ * @style: Default
+*/
+/**
+ * @style: Newdesign
+*/
+/**
+ * @style: Simple
+*/
+/**
+ * Colors
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Grid System.
+ * https://make.wordpress.org/design/2019/10/31/proposal-a-consistent-spacing-system-for-wordpress/
+ */
+/**
+ * Dimensions.
+ */
+/**
+ * Shadows.
+ */
+/**
+ * Editor widths.
+ */
+/**
+ * Block UI.
+ */
+/**
+ * Border radii.
+ */
+/**
+ * Breakpoint mixins
+ */
+/**
+ * Long content fade mixin
+ *
+ * Creates a fading overlay to signify that the content is longer
+ * than the space allows.
+ */
+/**
+ * Focus styles.
+ */
+/**
+ * Applies editor left position to the selector passed as argument
+ */
+/**
+ * Styles that are reused verbatim in a few places
+ */
+/**
+ * Allows users to opt-out of animations via OS-level preferences.
+ */
+/**
+ * Reset default styles for JavaScript UI based pages.
+ * This is a WP-admin agnostic reset
+ */
+/**
+ * Reset the WP Admin page styles for Gutenberg-like pages.
+ */
+:root {
+  --wp-admin-theme-color: #007cba;
+  --wp-admin-theme-color-darker-10: #006ba1;
+  --wp-admin-theme-color-darker-20: #005a87; }
+
+/**
+ * Breakpoints & Media Queries
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Border radius.
+ */
+/**
+ * #.# Mixins SCSS
+ *
+ * Mixins allow you to define styles that can be re-used throughout your stylesheet.
+*/
+html[amp] *, html[amp] *:before, html[amp] *:after {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link {
+  display: none; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit {
+  right: 20px; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit {
+  margin-right: 0; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * Colors
+ */
+/**
+ * Colors
+ */
+/**
+ * @style: Default
+*/
+/**
+ * @style: Newdesign
+*/
+/**
+ * @style: Simple
+*/
+/**
+ * Colors
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Grid System.
+ * https://make.wordpress.org/design/2019/10/31/proposal-a-consistent-spacing-system-for-wordpress/
+ */
+/**
+ * Dimensions.
+ */
+/**
+ * Shadows.
+ */
+/**
+ * Editor widths.
+ */
+/**
+ * Block UI.
+ */
+/**
+ * Border radii.
+ */
+/**
+ * Breakpoint mixins
+ */
+/**
+ * Long content fade mixin
+ *
+ * Creates a fading overlay to signify that the content is longer
+ * than the space allows.
+ */
+/**
+ * Focus styles.
+ */
+/**
+ * Applies editor left position to the selector passed as argument
+ */
+/**
+ * Styles that are reused verbatim in a few places
+ */
+/**
+ * Allows users to opt-out of animations via OS-level preferences.
+ */
+/**
+ * Reset default styles for JavaScript UI based pages.
+ * This is a WP-admin agnostic reset
+ */
+/**
+ * Reset the WP Admin page styles for Gutenberg-like pages.
+ */
+:root {
+  --wp-admin-theme-color: #007cba;
+  --wp-admin-theme-color-darker-10: #006ba1;
+  --wp-admin-theme-color-darker-20: #005a87; }
+
+/**
+ * Breakpoints & Media Queries
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Border radius.
+ */
+/**
+ * #.# Mixins SCSS
+ *
+ * Mixins allow you to define styles that can be re-used throughout your stylesheet.
+*/
+html[amp] *, html[amp] *:before, html[amp] *:after {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link {
+  display: none; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit {
+  right: 20px; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit {
+  margin-right: 0; }
+
+.custom-toast-container {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 9999; }
+
+.custom-toast {
+  background-color: #333;
+  color: #fff;
+  padding: 12px 20px;
+  border-radius: 4px;
+  margin-bottom: 10px;
+  -webkit-box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+          box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+  -webkit-transition: opacity 0.3s ease;
+  -o-transition: opacity 0.3s ease;
+  transition: opacity 0.3s ease; }
+
+.custom-toast--success {
+  background-color: #28a745 !important; }
+
+.custom-toast--error {
+  background-color: #dc3545 !important; }
+
+.custom-toast--insufficient-credit {
+  background-color: #dc3545 !important; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * Colors
+ */
+/**
+ * Colors
+ */
+/**
+ * @style: Default
+*/
+/**
+ * @style: Newdesign
+*/
+/**
+ * @style: Simple
+*/
+/**
+ * Colors
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Grid System.
+ * https://make.wordpress.org/design/2019/10/31/proposal-a-consistent-spacing-system-for-wordpress/
+ */
+/**
+ * Dimensions.
+ */
+/**
+ * Shadows.
+ */
+/**
+ * Editor widths.
+ */
+/**
+ * Block UI.
+ */
+/**
+ * Border radii.
+ */
+/**
+ * Breakpoint mixins
+ */
+/**
+ * Long content fade mixin
+ *
+ * Creates a fading overlay to signify that the content is longer
+ * than the space allows.
+ */
+/**
+ * Focus styles.
+ */
+/**
+ * Applies editor left position to the selector passed as argument
+ */
+/**
+ * Styles that are reused verbatim in a few places
+ */
+/**
+ * Allows users to opt-out of animations via OS-level preferences.
+ */
+/**
+ * Reset default styles for JavaScript UI based pages.
+ * This is a WP-admin agnostic reset
+ */
+/**
+ * Reset the WP Admin page styles for Gutenberg-like pages.
+ */
+:root {
+  --wp-admin-theme-color: #007cba;
+  --wp-admin-theme-color-darker-10: #006ba1;
+  --wp-admin-theme-color-darker-20: #005a87; }
+
+/**
+ * Breakpoints & Media Queries
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Border radius.
+ */
+/**
+ * #.# Mixins SCSS
+ *
+ * Mixins allow you to define styles that can be re-used throughout your stylesheet.
+*/
+html[amp] *, html[amp] *:before, html[amp] *:after {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link {
+  display: none; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit {
+  right: 20px; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit {
+  margin-right: 0; }
+
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+#wpadminbar #wp-admin-bar-edit-wpzoom-recipe > .ab-item:before {
+  content: url("data:image/svg+xml,%3Csvg version='1.1' xmlns='http://www.w3.org/2000/svg' width='20' height='20' style='fill:%2382878c' viewBox='0 0 32 32'%3E%3Ctitle%3Erecipe-cards%3C/title%3E%3Cpath d='M16.256 1.903c-2.895 0-5.457 1.653-6.813 4.277-3.598 0.031-6.38 3.186-6.38 6.994 0 2.715 1.454 5.154 3.679 6.297v8.467c0 0.873 0.659 1.629 1.53 1.629h15.495c0.872 0 1.53-0.756 1.53-1.629v-10.578c2.219-1.147 3.672-3.585 3.672-6.293 0-3.826-2.876-6.99-6.47-6.99-0.321 0-0.642 0.026-0.96 0.079-1.423-1.438-3.302-2.251-5.282-2.251zM11.816 8.467c0.704-2.022 2.452-3.307 4.439-3.307 1.4 0 2.671 0.641 3.584 1.826 0.394 0.51 1.048 0.724 1.651 0.517 0.33-0.113 0.669-0.17 1.007-0.17 1.853 0 3.409 1.647 3.409 3.733 0 1.706-1.060 3.175-2.54 3.598-0.683 0.196-1.132 0.852-1.132 1.573v4.355h-12.433v-2.247c0-0.721-0.45-1.38-1.136-1.574-1.479-0.419-2.542-1.887-2.542-3.597 0-2.053 1.578-3.736 3.371-3.736 0.196 0 0.394 0.021 0.588 0.062l0 0c0.751 0.157 1.477-0.299 1.732-1.032zM9.802 26.308v-2.459h12.433v2.459h-12.433z'%3E%3C/path%3E%3C/svg%3E%0A");
+  font-size: 16px !important;
+  top: 2px; }
+
+.wp-block-wpzoom-recipe-card-block-recipe-card {
+  max-width: 750px; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.recipe-card-noimage .recipe-card-image {
+    display: none; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.header-content-align-left .recipe-card-heading {
+    text-align: left; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.header-content-align-center .recipe-card-heading {
+    text-align: center; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.header-content-align-right .recipe-card-heading {
+    text-align: right; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-left, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-left, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-left {
+    margin-right: auto; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-left .recipe-card-summary,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-left .recipe-card-ingredients,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-left .recipe-card-directions,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-left .recipe-card-video,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-left .recipe-card-notes, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-left .recipe-card-summary,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-left .recipe-card-ingredients,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-left .recipe-card-directions,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-left .recipe-card-video,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-left .recipe-card-notes, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-left .recipe-card-summary,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-left .recipe-card-ingredients,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-left .recipe-card-directions,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-left .recipe-card-video,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-left .recipe-card-notes {
+      text-align: left; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-left .recipe-card-directions .directions-list > li img, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-left .recipe-card-directions .directions-list > li img, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-left .recipe-card-directions .directions-list > li img {
+      margin-right: auto; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-center, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-center, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-center {
+    margin-left: auto;
+    margin-right: auto; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right {
+    margin-left: auto; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-image figure figcaption, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-image figure figcaption, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-image figure figcaption {
+      text-align: right; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-summary,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-ingredients,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-directions,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-video,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-notes, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-summary,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-ingredients,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-directions,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-video,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-notes, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-summary,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-ingredients,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-directions,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-video,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-notes {
+      text-align: right; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-ingredients .ingredients-list > li .tick-circle, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-ingredients .ingredients-list > li .tick-circle, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-ingredients .ingredients-list > li .tick-circle {
+      float: right;
+      margin: 6px 0 0 10px; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-ingredients .ingredients-list .ingredient-item-name, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-ingredients .ingredients-list .ingredient-item-name, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-ingredients .ingredients-list .ingredient-item-name {
+      padding-left: 0;
+      padding-right: 30px; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-directions .directions-list > li, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-directions .directions-list > li, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-directions .directions-list > li {
+      padding-left: 0;
+      padding-right: 40px; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-directions .directions-list > li::before, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-directions .directions-list > li::before, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-directions .directions-list > li::before {
+        left: auto;
+        right: 0;
+        margin-right: 0;
+        margin-left: 20px; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-directions .directions-list > li img, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-directions .directions-list > li img, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-directions .directions-list > li img {
+        margin-left: auto; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default.block-alignment-right .recipe-card-notes .recipe-card-notes-list > li::before, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign.block-alignment-right .recipe-card-notes .recipe-card-notes-list > li::before, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-right .recipe-card-notes .recipe-card-notes-list > li::before {
+      left: auto;
+      right: -6px; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-center .recipe-card-image figure figcaption {
+    text-align: left; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.block-alignment-left .recipe-card-image figure figcaption {
+    text-align: left; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-heading .recipe-card-author {
+    margin-bottom: 10px; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-heading .recipe-card-title + p {
+    margin-bottom: 0; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-heading .wpzoom-recipe-card-print-link {
+    display: inline-block;
+    vertical-align: middle;
+    float: right;
+    border: 1px dashed rgba(0, 0, 0, 0.1);
+    padding: 5px; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-heading .wpzoom-recipe-card-print-link .btn-print-link {
+      display: block;
+      font-style: normal;
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 600;
+      line-height: 1.2;
+      color: #000;
+      border: none;
+      -webkit-box-shadow: none;
+              box-shadow: none;
+      -webkit-transition: .2s ease opacity;
+      -o-transition: .2s ease opacity;
+      transition: .2s ease opacity; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-heading .wpzoom-recipe-card-print-link .btn-print-link:hover {
+        opacity: .8; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-heading .wpzoom-recipe-card-print-link .btn-print-link .wpzoom-rcb-icon-print-link {
+        display: inline-block;
+        width: 22px;
+        height: 22px;
+        vertical-align: middle;
+        fill: #000; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-heading .wpzoom-recipe-card-print-link .btn-print-link .wpzoom-rcb-print-icon {
+        font-size: 18px;
+        margin-right: calc(6px);
+        vertical-align: middle; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-heading .wpzoom-recipe-card-print-link .btn-print-link span {
+        display: none; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-heading::after {
+    content: '';
+    clear: both;
+    display: table; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image figure img {
+    width: 100%; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image figure figcaption {
+    padding: 0;
+    margin: 0; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-video {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-video video {
+      max-width: 100%; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-video blockquote {
+      border: none;
+      font-size: 0; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-video blockquote * {
+        display: none; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-video blockquote iframe {
+        display: block; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-video [poster] {
+      -o-object-fit: cover;
+         object-fit: cover; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details {
+    margin-bottom: 15px;
+    clear: both; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .detail-item {
+      position: relative; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .detail-item > p:not(.detail-item-label):not(.detail-item-value):not(.detail-item-unit) {
+        display: none; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .detail-item .detail-item-label {
+        margin-bottom: 5px; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .detail-item .detail-item-unit {
+        margin-bottom: 0; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .detail-item .detail-item-input-wrapper {
+        position: relative;
+        display: -ms-inline-flexbox;
+        display: inline-flex;
+        -ms-flex-align: center;
+            align-items: center; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .detail-item .wpzoom-info-icon {
+        display: inline-block;
+        margin-left: 5px;
+        cursor: help;
+        vertical-align: text-bottom;
+        position: relative; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .detail-item .wpzoom-info-icon:hover {
+          opacity: 0.8; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .detail-item .wpzoom-info-icon svg {
+          width: 12px;
+          height: 12px;
+          -webkit-filter: drop-shadow(0px 1px 1px rgba(0, 0, 0, 0.1));
+                  filter: drop-shadow(0px 1px 1px rgba(0, 0, 0, 0.1));
+          vertical-align: middle; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .detail-item .components-tooltip {
+        position: absolute !important;
+        bottom: 100% !important;
+        left: 50% !important;
+        -webkit-transform: translateX(-50%) translateY(-4px) !important;
+            -ms-transform: translateX(-50%) translateY(-4px) !important;
+                transform: translateX(-50%) translateY(-4px) !important;
+        background: #333 !important;
+        color: white !important;
+        padding: 8px 12px !important;
+        border-radius: 4px !important;
+        font-size: 13px !important;
+        white-space: nowrap !important;
+        -webkit-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2) !important;
+                box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2) !important;
+        z-index: 9999 !important; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-details .detail-item .components-tooltip::before {
+          content: '' !important;
+          position: absolute !important;
+          bottom: -4px !important;
+          left: 50% !important;
+          -webkit-transform: translateX(-50%) !important;
+              -ms-transform: translateX(-50%) !important;
+                  transform: translateX(-50%) !important;
+          width: 0 !important;
+          height: 0 !important;
+          border-left: 5px solid transparent !important;
+          border-right: 5px solid transparent !important;
+          border-top: 5px solid #333 !important; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-ingredients .ingredients-list {
+    margin: 0;
+    padding: 0; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-ingredients .ingredients-list > li {
+      padding-left: 0; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-ingredients .ingredients-list .ingredient-item-name {
+      padding-left: 30px;
+      margin: 0;
+      vertical-align: middle; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .hidden {
+    display: none !important; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-directions + .footer-copyright {
+    margin-top: 30px; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-directions .directions-list .direction-step-group {
+    counter-reset: count; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-directions .directions-list .direction-step-group::before {
+      content: '';
+      counter-increment: none; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .direction-step img {
+    display: block;
+    clear: both; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .footer-copyright p {
+    margin-bottom: 0;
+    text-align: center;
+    font-size: 12px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    color: #ababab; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card .footer-copyright p a {
+      color: #222222;
+      text-decoration: none;
+      padding-bottom: 2px;
+      border-bottom: 1px solid #eee; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card .footer-copyright p a:hover {
+        text-decoration: none;
+        border-bottom-color: #ccc; }
+
+.wpzoom-recipe-card-buttons {
+  text-align: center; }
+
+.wpzoom-recipe-snippet-button.wp-block-wpzoom-recipe-card-block-print-recipe,
+.wpzoom-recipe-snippet-button.wp-block-wpzoom-recipe-card-block-jump-to-recipe,
+.wpzoom-recipe-card-buttons a.wpzoom-recipe-snippet-button {
+  display: inline-block;
+  border-radius: 3px;
+  padding: 10px 20px;
+  font-style: normal;
+  text-decoration: none;
+  font-size: 14px;
+  color: #fff;
+  line-height: 1.2;
+  background-color: #041728;
+  border: none;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+  margin-right: 10px;
+  margin-bottom: 15px;
+  font-weight: 600; }
+  .wpzoom-recipe-snippet-button.wp-block-wpzoom-recipe-card-block-print-recipe:hover,
+  .wpzoom-recipe-snippet-button.wp-block-wpzoom-recipe-card-block-jump-to-recipe:hover,
+  .wpzoom-recipe-card-buttons a.wpzoom-recipe-snippet-button:hover {
+    color: #fff;
+    background-color: #0e2e4b; }
+  .wpzoom-recipe-snippet-button.wp-block-wpzoom-recipe-card-block-print-recipe svg,
+  .wpzoom-recipe-snippet-button.wp-block-wpzoom-recipe-card-block-jump-to-recipe svg,
+  .wpzoom-recipe-card-buttons a.wpzoom-recipe-snippet-button svg {
+    display: inline-block;
+    margin-right: 6px;
+    width: 16px;
+    height: 16px;
+    vertical-align: middle;
+    fill: #fff; }
+
+@media screen and (max-width: 600px) {
+  .wpzoom-recipe-snippet-button.wp-block-wpzoom-recipe-card-block-print-recipe, .wpzoom-recipe-snippet-button.wp-block-wpzoom-recipe-card-block-jump-to-recipe, .wpzoom-recipe-card-buttons a.wpzoom-recipe-snippet-button {
+    padding: 10px 15px; } }
+
+@media screen and (max-width: 360px) {
+  .wpzoom-recipe-snippet-button.wp-block-wpzoom-recipe-card-block-print-recipe, .wpzoom-recipe-snippet-button.wp-block-wpzoom-recipe-card-block-jump-to-recipe, .wpzoom-recipe-card-buttons a.wpzoom-recipe-snippet-button {
+    padding: 10px; } }
+
+.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default {
+  padding: 20px 25px 30px;
+  margin-top: 50px;
+  margin-bottom: 50px;
+  background: #ffffff;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: 0 0px 15px rgba(0, 0, 0, 0.1);
+          box-shadow: 0 0px 15px rgba(0, 0, 0, 0.1);
+  border-radius: 5px 5px 0 0; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image {
+    margin-top: -21px;
+    margin-left: -26px;
+    margin-right: -26px;
+    margin-bottom: 20px; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image figure {
+      position: relative;
+      margin: 0;
+      line-height: 0; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image figure img {
+        max-width: 100%;
+        width: 100%;
+        height: auto;
+        margin: 0;
+        border-radius: 5px 5px 0 0; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image figure::before {
+        content: '';
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        top: 0;
+        left: 0;
+        z-index: 1;
+        background: -webkit-gradient(linear, left bottom, left top, from(rgba(0, 0, 0, 0.65)), color-stop(35%, rgba(0, 0, 0, 0)));
+        background: -webkit-linear-gradient(bottom, rgba(0, 0, 0, 0.65) 0%, rgba(0, 0, 0, 0) 35%);
+        background: -o-linear-gradient(bottom, rgba(0, 0, 0, 0.65) 0%, rgba(0, 0, 0, 0) 35%);
+        background: linear-gradient(to top, rgba(0, 0, 0, 0.65) 0%, rgba(0, 0, 0, 0) 35%); }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image figure figcaption {
+        position: absolute;
+        right: 20px;
+        left: 20px;
+        text-align: right;
+        bottom: 8px;
+        padding-bottom: 10px;
+        z-index: 2;
+        line-height: 1.8; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-print-link {
+      display: inline-block;
+      vertical-align: middle; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link {
+        display: block;
+        border-radius: 4px;
+        padding: 10px 20px;
+        font-style: normal;
+        text-decoration: none;
+        font-size: 14px;
+        font-weight: 600;
+        line-height: 1.2;
+        color: #fff;
+        background-color: #222222;
+        border: none;
+        -webkit-box-shadow: none;
+                box-shadow: none;
+        -webkit-transition: .2s ease opacity;
+        -o-transition: .2s ease opacity;
+        transition: .2s ease opacity; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link:hover {
+          opacity: .8; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link .wpzoom-rcb-icon-print-link {
+          display: inline-block;
+          margin-right: 8px;
+          width: 16px;
+          height: 16px;
+          vertical-align: middle;
+          fill: #fff; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link .wpzoom-rcb-print-icon {
+          font-size: 18px;
+          margin-right: calc(6px);
+          vertical-align: middle; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link .wpzoom-rcb-print-icon + span {
+          font-size: 14px;
+          vertical-align: middle; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-pinit {
+      display: inline-block;
+      vertical-align: middle;
+      margin-right: 10px; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link {
+        cursor: pointer;
+        display: block;
+        border-radius: 4px;
+        padding: 10px 20px;
+        text-decoration: none;
+        font-size: 14px;
+        font-weight: 600;
+        color: #fff;
+        line-height: 1.2;
+        border: none;
+        -webkit-box-shadow: none;
+                box-shadow: none;
+        background-color: #C62122;
+        -webkit-transition: .2s ease opacity;
+        -o-transition: .2s ease opacity;
+        transition: .2s ease opacity; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link:hover {
+          opacity: .8; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link .wpzoom-rcb-icon-pinit-link {
+          display: inline-block;
+          margin-right: 8px;
+          width: 16px;
+          height: 16px;
+          vertical-align: middle;
+          fill: #fff; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link .wpzoom-rcb-pinit-icon {
+          font-size: 18px;
+          margin-right: calc(6px);
+          vertical-align: middle; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link .wpzoom-rcb-pinit-icon + span {
+          font-size: 14px;
+          vertical-align: middle; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-heading {
+    margin-bottom: 15px; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-heading .recipe-card-title {
+      font-size: 30px;
+      font-weight: 600;
+      font-family: inherit;
+      margin: 0 0 10px; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-heading .recipe-card-author {
+      display: block;
+      color: #5b5d61;
+      font-size: 14px;
+      font-weight: normal;
+      font-style: italic;
+      margin: 0 0 12px;
+      padding: 0 0 12px;
+      border-bottom: 1px dashed rgba(0, 0, 0, 0.1); }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-heading .recipe-card-course,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-heading .recipe-card-cuisine,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-heading .recipe-card-difficulty {
+      font-size: 14px;
+      color: #5b5d61; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-heading .recipe-card-course mark,
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-heading .recipe-card-cuisine mark,
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-heading .recipe-card-difficulty mark {
+        color: #222222;
+        font-weight: 600;
+        background: transparent;
+        padding: 0; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-heading span:not(.recipe-card-author) + span:not(.recipe-card-author):before {
+      content: " / ";
+      color: #B6BABB;
+      margin: 0 12px;
+      font-style: normal;
+      opacity: .5; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items {
+    font-size: 0;
+    border-left: 1px dashed rgba(0, 0, 0, 0.1);
+    border-top: 1px dashed rgba(0, 0, 0, 0.1);
+    text-align: center;
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-wrap: wrap;
+        flex-wrap: wrap; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item {
+      -ms-flex: 1 0 25%;
+          flex: 1 0 25%;
+      padding: 10px 1.5%;
+      position: relative;
+      -webkit-box-sizing: border-box;
+              box-sizing: border-box;
+      border-right: 1px dashed rgba(0, 0, 0, 0.1);
+      border-bottom: 1px dashed rgba(0, 0, 0, 0.1); }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-label {
+        font-weight: bold; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-label, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-value, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-unit {
+        font-size: 14px; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-icon, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-label {
+        display: block; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-value {
+        font-weight: 500;
+        margin: 0 5px 0 0; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-value, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-unit {
+        display: inline-block;
+        line-height: 1.4; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-icon {
+        opacity: .7;
+        margin: 0 auto;
+        height: 35px;
+        line-height: 35px;
+        font-size: 16px;
+        color: #6d767f; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-icon .components-icon-button {
+          margin: 0 auto !important; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-icon span {
+        color: #6d767f; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-icon span::before {
+          font-size: 16px; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-icon svg {
+        fill: #6d767f; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-summary {
+    margin-bottom: 20px !important;
+    font-size: 14px; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .ingredients-title {
+    font-size: 22px;
+    font-weight: 600;
+    color: #222222;
+    margin: 0 0 20px;
+    padding: 0;
+    background-color: transparent;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .directions-title {
+    font-size: 22px;
+    font-weight: 600;
+    color: #222222;
+    margin: 0 0 20px;
+    padding: 0;
+    background-color: transparent;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .video-title {
+    font-size: 22px;
+    font-weight: 600;
+    color: #222222;
+    margin: 0 0 20px;
+    padding: 0;
+    background-color: transparent;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .notes-title {
+    font-size: 22px;
+    font-weight: 600;
+    color: #222222;
+    margin: 0 0 20px;
+    padding: 0;
+    background-color: transparent;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .directions-title {
+    margin-bottom: 25px; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions .directions-header {
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-pack: justify;
+        justify-content: space-between;
+    -ms-flex-align: center;
+        align-items: center;
+    margin-bottom: 20px; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions .image-switcher-container .toggle-input {
+    display: none; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions .image-switcher-container .toggle-switch {
+    position: relative;
+    width: 54px;
+    height: 28px;
+    background-color: #e2e8f0;
+    border-radius: 30px;
+    cursor: pointer;
+    -webkit-transition: all 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+    -o-transition: all 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+    transition: all 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-align: center;
+        align-items: center; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions .image-switcher-container .toggle-switch::after {
+      content: "";
+      position: absolute;
+      z-index: 2;
+      width: 22px;
+      height: 22px;
+      background-color: white;
+      border-radius: 50%;
+      left: 3px;
+      -webkit-transition: all 0.3s ease;
+      -o-transition: all 0.3s ease;
+      transition: all 0.3s ease;
+      -webkit-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+              box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2); }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions .image-switcher-container .toggle-switch svg {
+      position: absolute;
+      z-index: 1;
+      -webkit-transition: all 0.3s ease;
+      -o-transition: all 0.3s ease;
+      transition: all 0.3s ease;
+      stroke: #64748b; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions .image-switcher-container .toggle-switch .icon-camera {
+      left: 8px;
+      opacity: 0;
+      -webkit-transform: scale(0.5);
+          -ms-transform: scale(0.5);
+              transform: scale(0.5); }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions .image-switcher-container .toggle-switch .icon-camera-off {
+      right: 8px;
+      opacity: 1; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions .image-switcher-container .toggle-input:checked + .toggle-label .toggle-switch {
+    background-color: #f43f5e; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions .image-switcher-container .toggle-input:checked + .toggle-label .toggle-switch::after {
+      -webkit-transform: translateX(26px);
+          -ms-transform: translateX(26px);
+              transform: translateX(26px); }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions .image-switcher-container .toggle-input:checked + .toggle-label .toggle-switch .icon-camera {
+      opacity: 1;
+      -webkit-transform: scale(1);
+          -ms-transform: scale(1);
+              transform: scale(1);
+      stroke: white; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions .image-switcher-container .toggle-input:checked + .toggle-label .toggle-switch .icon-camera-off {
+      opacity: 0;
+      -webkit-transform: scale(0.5);
+          -ms-transform: scale(0.5);
+              transform: scale(0.5); }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions:has(#direction-images-toggle-checkbox:not(:checked)) .directions-list img {
+    display: none !important; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-ingredients {
+    position: relative;
+    color: #736458;
+    background-color: #FBF9E7;
+    border-radius: 3px;
+    margin: 0 0 30px;
+    padding: 25px 25px 5px;
+    text-align: left; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .ingredients-list {
+    margin: 0;
+    padding: 0;
+    list-style: none; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .ingredients-list > li {
+      list-style: none;
+      padding: 0 0 13px;
+      margin: 0 0 13px;
+      border-bottom: 1px solid #e9e5c9;
+      position: relative;
+      line-height: 1.7; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .ingredients-list > li.ingredient-item-group {
+        cursor: initial; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .ingredients-list > li:last-child {
+        border-bottom: none; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .ingredients-list > li::after {
+        content: '';
+        clear: both;
+        display: table; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .ingredients-list > li .tick-circle {
+        content: '';
+        float: left;
+        width: 18px;
+        height: 18px;
+        margin: 6px 10px 0 0;
+        border-radius: 50%;
+        border: 2px solid #DEDAB6;
+        cursor: pointer;
+        position: relative; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .ingredients-list > li.ticked .ingredient-item-name.is-strikethrough-active {
+        text-decoration: line-through; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .ingredients-list > li.ticked .tick-circle {
+        border: 2px solid #9AD093 !important;
+        background: #9AD093;
+        -webkit-box-shadow: inset 0px 0px 0px 2px #fff;
+                box-shadow: inset 0px 0px 0px 2px #fff; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .directions-list {
+    counter-reset: count;
+    line-height: normal;
+    list-style: none;
+    margin: 0;
+    padding: 0; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .directions-list > li {
+      position: relative;
+      line-height: 1.8;
+      list-style: none;
+      padding-left: 40px;
+      margin: 0 0 15px; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .directions-list > li::before {
+        counter-increment: count;
+        content: counter(count);
+        display: block;
+        position: absolute;
+        top: 0;
+        left: 0;
+        font-size: 24px;
+        font-weight: bold;
+        text-transform: uppercase;
+        line-height: 1.4;
+        color: #222222;
+        background: none;
+        width: 35px;
+        vertical-align: middle;
+        padding: 0;
+        margin-right: 20px; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .directions-list > li:last-child {
+        margin: 0; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .directions-list > li .direction-step-text {
+        margin-bottom: 20px;
+        font-size: 14px; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .directions-list > li .direction-step-text img {
+          max-width: 100%;
+          height: auto;
+          display: block; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .directions-list > li:last-child .direction-step-text {
+        margin-bottom: 0; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .direction-step img {
+    margin: 10px 0;
+    max-width: 100%;
+    height: auto;
+    display: block; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-notes {
+    margin-top: 30px;
+    padding-top: 20px;
+    border-top: 1px dashed rgba(0, 0, 0, 0.1);
+    margin-bottom: 30px; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-notes .recipe-card-notes-list,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-notes ul {
+      margin: 0;
+      padding: 0;
+      list-style: none; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-notes .recipe-card-notes-list > li:empty,
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-notes ul > li:empty {
+        display: none; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-notes .recipe-card-notes-list > li,
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-notes ul > li {
+        position: relative;
+        background-color: #FBF9E7;
+        color: #736458;
+        margin: 0 0 15px;
+        padding: 20px 25px 20px 50px;
+        list-style-type: none;
+        font-size: 14px;
+        border-radius: 5px; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-notes .recipe-card-notes-list > li::before,
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-notes ul > li::before {
+          content: "i";
+          position: absolute;
+          display: block;
+          color: #fff;
+          background-color: #222222;
+          border-radius: 8px;
+          width: 16px;
+          height: 16px;
+          line-height: 16px;
+          font-size: 12px;
+          text-align: center;
+          left: 14px;
+          top: 50%;
+          -webkit-transform: translateY(-50%);
+              -ms-transform: translateY(-50%);
+                  transform: translateY(-50%); }
+
+@media screen and (max-width: 700px) {
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-image {
+    margin-bottom: 15px; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-heading .recipe-card-title {
+    font-size: 24px; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items {
+    -ms-flex-wrap: wrap;
+        flex-wrap: wrap; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item {
+      min-width: 50%;
+      padding: 7px 1.5%;
+      border-bottom: 1px dashed rgba(0, 0, 0, 0.1); } }
+
+@media screen and (max-width: 460px) {
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .details-items .detail-item .detail-item-icon {
+    display: none; } }
+
+.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign {
+  padding: 20px 30px 35px;
+  margin-top: 50px;
+  margin-bottom: 50px;
+  background: #ffffff;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: 0 0px 15px rgba(0, 0, 0, 0.1);
+          box-shadow: 0 0px 15px rgba(0, 0, 0, 0.1);
+  border-radius: 5px 5px 0 0; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image {
+    margin-top: -21px;
+    margin-left: -31px;
+    margin-right: -31px;
+    margin-bottom: 30px; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image figure {
+      position: relative;
+      margin: 0;
+      line-height: 0; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image figure img {
+        max-width: 100%;
+        width: 100%;
+        height: auto;
+        margin: 0;
+        border-radius: 5px 5px 0 0; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-print-link {
+      position: absolute;
+      right: 20px;
+      bottom: -26px;
+      z-index: 2;
+      line-height: 1.8; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link {
+        display: block;
+        width: 52px;
+        height: 52px;
+        border-radius: 50%;
+        padding: 10px 8px;
+        text-align: center;
+        text-decoration: none;
+        font-size: 12px;
+        color: #fff;
+        line-height: 1.2;
+        background-color: #FFA921;
+        -webkit-box-shadow: 0 5px 40px #FFA921;
+                box-shadow: 0 5px 40px #FFA921;
+        border: none;
+        -webkit-transition: .2s ease box-shadow;
+        -o-transition: .2s ease box-shadow;
+        transition: .2s ease box-shadow; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link:hover {
+          opacity: .9;
+          -webkit-box-shadow: 0 15px 10px #FFA921;
+                  box-shadow: 0 15px 10px #FFA921; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link .wpzoom-rcb-icon-print-link {
+          margin: auto;
+          margin-bottom: 5px;
+          display: block;
+          width: 16px;
+          height: 16px;
+          fill: #fff; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link .wpzoom-rcb-print-icon {
+          font-size: 18px;
+          margin-right: calc(6px);
+          vertical-align: middle; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link .wpzoom-rcb-print-icon + span {
+          font-size: 14px;
+          vertical-align: middle; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-pinit {
+      position: absolute;
+      right: 90px;
+      bottom: -26px;
+      z-index: 2;
+      line-height: 1.8; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link {
+        cursor: pointer;
+        display: block;
+        width: 52px;
+        height: 52px;
+        border-radius: 50%;
+        padding: 10px 8px;
+        text-align: center;
+        text-decoration: none;
+        font-size: 12px;
+        color: #fff;
+        line-height: 1.2;
+        background-color: #C62122;
+        -webkit-box-shadow: 0 5px 40px #C62122;
+                box-shadow: 0 5px 40px #C62122;
+        outline: 0;
+        -webkit-transition: .2s ease box-shadow;
+        -o-transition: .2s ease box-shadow;
+        transition: .2s ease box-shadow; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link:hover {
+          opacity: .8;
+          -webkit-box-shadow: 0 5px 30px #C62122;
+                  box-shadow: 0 5px 30px #C62122; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link .wpzoom-rcb-icon-pinit-link {
+          margin: auto;
+          margin-bottom: 5px;
+          display: block;
+          width: 16px;
+          height: 16px;
+          fill: #fff; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link .wpzoom-rcb-pinit-icon {
+          font-size: 18px;
+          margin-right: calc(6px);
+          vertical-align: middle; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link .wpzoom-rcb-pinit-icon + span {
+          font-size: 14px;
+          vertical-align: middle; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-heading {
+    margin-bottom: 15px; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-heading .recipe-card-title {
+      font-size: 30px;
+      font-weight: 600;
+      font-family: inherit;
+      margin: 0 0 10px; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-heading .recipe-card-author {
+      display: block;
+      color: #5b5d61;
+      font-size: 14px;
+      font-weight: normal;
+      font-style: italic;
+      margin: 0 0 15px;
+      padding: 0 0 15px;
+      border-bottom: 1px dashed rgba(0, 0, 0, 0.1); }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-heading .recipe-card-course,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-heading .recipe-card-cuisine,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-heading .recipe-card-difficulty {
+      font-size: 14px;
+      color: #5b5d61; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-heading .recipe-card-course mark,
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-heading .recipe-card-cuisine mark,
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-heading .recipe-card-difficulty mark {
+        color: #222222;
+        font-weight: 600;
+        background: transparent;
+        padding: 0; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-heading span:not(.recipe-card-author) + span:not(.recipe-card-author):before {
+      content: " / ";
+      color: #B6BABB;
+      margin: 0 12px;
+      font-style: normal;
+      opacity: .5; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items {
+    font-size: 0;
+    border-left: 1px dashed rgba(0, 0, 0, 0.1);
+    border-top: 1px dashed rgba(0, 0, 0, 0.1);
+    text-align: center;
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-wrap: wrap;
+        flex-wrap: wrap; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item {
+      -ms-flex: 1 0 25%;
+          flex: 1 0 25%;
+      padding: 10px 1.5%;
+      position: relative;
+      -webkit-box-sizing: border-box;
+              box-sizing: border-box;
+      border-right: 1px dashed rgba(0, 0, 0, 0.1);
+      border-bottom: 1px dashed rgba(0, 0, 0, 0.1); }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-label {
+        font-weight: bold; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-label, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-value, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-unit {
+        font-size: 14px; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-icon, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-label {
+        display: block; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-value {
+        font-weight: 500;
+        margin-right: 5px;
+        margin-bottom: 0; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-value, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-unit {
+        display: inline-block;
+        line-height: 1.4; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-icon {
+        height: 35px;
+        line-height: 35px;
+        font-size: 16px;
+        margin: auto;
+        color: #6d767f; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-icon span {
+          color: #6d767f; }
+          .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-icon span::before {
+            font-size: 16px; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-icon svg {
+          fill: #6d767f; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-icon .components-icon-button {
+          margin: 0 auto !important; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-summary {
+    margin-bottom: 20px !important; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-ingredients {
+    margin: 15px 0 30px;
+    padding: 25px 0;
+    border-top: 1px dashed rgba(0, 0, 0, 0.1);
+    border-bottom: 1px dashed rgba(0, 0, 0, 0.1);
+    position: relative;
+    text-align: left; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-title {
+    font-size: 22px;
+    font-weight: 600;
+    color: #222222;
+    margin: 0 0 20px;
+    padding: 0;
+    background-color: transparent;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .directions-title {
+    font-size: 22px;
+    font-weight: 600;
+    color: #222222;
+    margin: 0 0 20px;
+    padding: 0;
+    background-color: transparent;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .video-title {
+    font-size: 22px;
+    font-weight: 600;
+    color: #222222;
+    margin: 0 0 20px;
+    padding: 0;
+    background-color: transparent;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .notes-title {
+    font-size: 22px;
+    font-weight: 600;
+    color: #222222;
+    margin: 0 0 20px;
+    padding: 0;
+    background-color: transparent;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list {
+    margin: 0;
+    padding: 0;
+    list-style: none; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list > li {
+      list-style: none;
+      margin: 0 0 10px;
+      position: relative;
+      line-height: 1.7; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list > li.ingredient-item-group {
+        cursor: initial; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list > li::after {
+        content: '';
+        clear: both;
+        display: table; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list > li .tick-circle {
+        content: '';
+        float: left;
+        width: 18px;
+        height: 18px;
+        margin: 6px 10px 0 0;
+        border-radius: 50%;
+        border: 2px solid #FFA921;
+        cursor: pointer;
+        position: relative; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list > li.ticked .ingredient-item-name.is-strikethrough-active {
+        text-decoration: line-through; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list > li.ticked .tick-circle {
+        border: 2px solid #9AD093 !important;
+        background: #9AD093;
+        -webkit-box-shadow: inset 0px 0px 0px 2px #fff;
+                box-shadow: inset 0px 0px 0px 2px #fff; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list.layout-2-columns {
+      -webkit-columns: 2;
+         -moz-columns: 2;
+              columns: 2; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list.layout-2-columns .ingredient-item-group {
+        -webkit-column-span: all;
+           -moz-column-span: all;
+                column-span: all; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .directions-list {
+    counter-reset: count;
+    line-height: normal;
+    list-style: none;
+    margin: 0;
+    padding: 0; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .directions-list > li {
+      position: relative;
+      line-height: 1.8;
+      list-style: none;
+      padding-left: 40px;
+      margin: 0 0 15px; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .directions-list > li::before {
+        counter-increment: count;
+        content: counter(count);
+        display: block;
+        position: absolute;
+        top: 0;
+        left: 0;
+        font-size: 24px;
+        font-weight: bold;
+        text-transform: uppercase;
+        line-height: 1.4;
+        color: #222222;
+        background: none;
+        width: 35px;
+        vertical-align: middle;
+        padding: 0;
+        margin-right: 20px; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .directions-list > li:last-child {
+        margin: 0; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .directions-list > li .direction-step-text {
+        margin-bottom: 20px; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .directions-list > li .direction-step-text img {
+          max-width: 100%;
+          height: auto;
+          display: block; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .directions-list > li:last-child .direction-step-text {
+        margin-bottom: 0; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .direction-step img {
+    margin: 10px 0;
+    max-width: 100%;
+    height: auto;
+    display: block; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-notes {
+    margin-top: 30px;
+    margin-bottom: 30px; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-notes .recipe-card-notes-list,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-notes ul {
+      margin: 0;
+      padding: 0;
+      list-style: none; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-notes .recipe-card-notes-list > li:empty,
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-notes ul > li:empty {
+        display: none; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-notes .recipe-card-notes-list > li,
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-notes ul > li {
+        position: relative;
+        background-color: #f5f5f5;
+        color: inherit;
+        margin: 0 0 15px;
+        padding: 20px 25px 20px 50px;
+        list-style-type: none;
+        font-size: 14px;
+        border-radius: 5px; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-notes .recipe-card-notes-list > li::before,
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-notes ul > li::before {
+          content: "i";
+          position: absolute;
+          display: block;
+          color: #fff;
+          background-color: #FFA921;
+          border-radius: 8px;
+          width: 16px;
+          height: 16px;
+          line-height: 16px;
+          font-size: 12px;
+          text-align: center;
+          left: 14px;
+          top: 50%;
+          -webkit-transform: translateY(-50%);
+              -ms-transform: translateY(-50%);
+                  transform: translateY(-50%); }
+
+@media screen and (max-width: 700px) {
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-image {
+    margin-bottom: 15px; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .recipe-card-heading .recipe-card-title {
+    font-size: 24px; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item {
+    min-width: 50%;
+    padding: 7px 1.5%;
+    border-bottom: 1px dashed rgba(0, 0, 0, 0.1); }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .ingredients-list.layout-2-columns {
+    -webkit-columns: 1;
+       -moz-columns: 1;
+            columns: 1; } }
+
+@media screen and (max-width: 460px) {
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-newdesign .details-items .detail-item .detail-item-icon {
+    display: none; } }
+
+.wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple {
+  padding: 25px;
+  border-radius: 10px;
+  margin-top: 50px;
+  margin-bottom: 50px;
+  background: #ffffff;
+  border: 1px solid rgba(0, 0, 0, 0.1); }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-header-wrap {
+    margin: -26px -26px 25px -26px;
+    padding: 25px;
+    background-color: #FFF3E0;
+    border-radius: 10px 10px 0 0; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-header-wrap::after {
+      content: '';
+      clear: both;
+      display: table; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.header-content-align-right .recipe-card-image {
+    float: right;
+    text-align: right; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.header-content-align-right .recipe-card-along-image {
+    float: left;
+    text-align: right; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.header-content-align-right .recipe-card-heading,
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.header-content-align-right .recipe-card-details {
+    margin-right: 20px;
+    margin-left: 0; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.header-content-align-right .details-items .detail-item {
+    margin-right: 0;
+    margin-left: 15px; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image {
+    float: left;
+    width: 40%; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image figure {
+      position: relative;
+      margin: 0;
+      line-height: 0; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image figure img {
+        max-width: 100%;
+        width: 100%;
+        height: auto;
+        margin: 0;
+        border-radius: 8px; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image figure figcaption {
+        margin-top: 10px;
+        line-height: 1.8; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-pinit,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-print-link {
+      display: inline-block;
+      vertical-align: middle; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-pinit {
+      margin-right: 12px; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link {
+        display: block;
+        border-radius: 4px;
+        padding: 8px 16px;
+        font-style: normal;
+        text-decoration: none;
+        font-size: 14px;
+        font-weight: 600;
+        color: #fff;
+        line-height: 1.4;
+        border: none;
+        -webkit-box-shadow: none;
+                box-shadow: none;
+        cursor: pointer;
+        background-color: #C62122;
+        -webkit-transition: .2s ease opacity;
+        -o-transition: .2s ease opacity;
+        transition: .2s ease opacity; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link:hover {
+          opacity: .8; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link .wpzoom-rcb-icon-pinit-link {
+          display: inline-block;
+          margin-right: 8px;
+          width: 16px;
+          height: 16px;
+          vertical-align: middle;
+          fill: #fff; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link .wpzoom-rcb-pinit-icon {
+          font-size: 18px;
+          margin-right: calc(6px);
+          vertical-align: middle; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-pinit .btn-pinit-link .wpzoom-rcb-pinit-icon + span {
+          font-size: 14px;
+          vertical-align: middle; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link {
+      display: block;
+      border-radius: 4px;
+      padding: 8px 16px;
+      font-style: normal;
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 600;
+      color: #fff;
+      line-height: 1.4;
+      border: none;
+      -webkit-box-shadow: none;
+              box-shadow: none;
+      cursor: pointer;
+      color: #fff;
+      background-color: #222222;
+      -webkit-transition: .2s ease opacity;
+      -o-transition: .2s ease opacity;
+      transition: .2s ease opacity; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link:hover {
+        opacity: .8; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link .wpzoom-rcb-icon-print-link {
+        display: inline-block;
+        margin-right: 8px;
+        width: 16px;
+        height: 16px;
+        vertical-align: middle;
+        fill: #fff; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link .wpzoom-rcb-print-icon {
+        font-size: 18px;
+        margin-right: calc(6px);
+        vertical-align: middle; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image .wpzoom-recipe-card-print-link .btn-print-link .wpzoom-rcb-print-icon + span {
+        font-size: 14px;
+        vertical-align: middle; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-along-image {
+    float: right;
+    width: 60%; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading {
+    margin-bottom: 5px;
+    margin-left: 20px; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-title {
+      font-size: 24px;
+      font-weight: 600;
+      font-family: inherit;
+      margin: 0 0 10px; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-author {
+      display: block;
+      color: #5b5d61;
+      font-size: 14px;
+      font-weight: normal;
+      font-style: italic;
+      margin: 0 0 6px;
+      padding: 0 0 12px;
+      border-bottom: 1px dashed rgba(0, 0, 0, 0.1); }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-course,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-cuisine,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-difficulty {
+      font-size: 14px;
+      color: #5b5d61; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-course mark,
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-cuisine mark,
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-difficulty mark {
+        color: #222222;
+        font-weight: 600;
+        background: transparent;
+        padding: 0; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading span:not(.recipe-card-author) + span:not(.recipe-card-author):before {
+      content: " / ";
+      color: #B6BABB;
+      margin: 0 12px;
+      font-style: normal;
+      opacity: .5; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-course,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-cuisine,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-difficulty {
+      font-size: 14px;
+      color: #5b5d61;
+      display: inline-block;
+      margin-bottom: 5px; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-course mark,
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-cuisine mark,
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading .recipe-card-difficulty mark {
+        color: #222222;
+        font-weight: 600;
+        background: transparent;
+        padding: 0; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading span:not(.recipe-card-author) + span:not(.recipe-card-author):before {
+      content: " / ";
+      color: #B6BABB;
+      margin: 0 12px;
+      font-style: normal;
+      opacity: .5; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-details {
+    margin-left: 20px;
+    margin-bottom: 0;
+    padding-top: 5px;
+    border-top: 1px dashed rgba(0, 0, 0, 0.1); }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item {
+    color: #333;
+    display: inline-block;
+    vertical-align: middle;
+    margin-right: 15px; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-label {
+      font-weight: bold;
+      margin-right: 5px; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-label, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-value, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-unit {
+      font-size: 14px; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-icon, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-label {
+      display: inline-block; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-value {
+      font-weight: 500;
+      margin: 0 5px 0 0; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-value, .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-unit {
+      display: inline-block;
+      line-height: 1.4; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-icon {
+      opacity: .7;
+      margin: 0;
+      margin-right: 10px;
+      height: 35px;
+      line-height: 35px;
+      font-size: 16px;
+      color: #6d767f;
+      display: inline-block; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-icon .components-icon-button {
+        margin: 0 auto !important; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-icon span {
+      color: #6d767f; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-icon span::before {
+        font-size: 16px; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .details-items .detail-item .detail-item-icon svg {
+      fill: #6d767f; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-summary {
+    margin-bottom: 20px !important; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .ingredients-title {
+    font-size: 22px;
+    font-weight: 600;
+    color: #222222;
+    margin: 0 0 20px;
+    padding: 0;
+    background-color: transparent;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .directions-title {
+    font-size: 22px;
+    font-weight: 600;
+    color: #222222;
+    margin: 0 0 20px;
+    padding: 0;
+    background-color: transparent;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .video-title {
+    font-size: 22px;
+    font-weight: 600;
+    color: #222222;
+    margin: 0 0 20px;
+    padding: 0;
+    background-color: transparent;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .notes-title {
+    font-size: 22px;
+    font-weight: 600;
+    color: #222222;
+    margin: 0 0 20px;
+    padding: 0;
+    background-color: transparent;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .directions-title {
+    margin-bottom: 25px; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-ingredients {
+    position: relative;
+    margin: 0 0 30px;
+    text-align: left; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .ingredients-list {
+    margin: 0;
+    padding: 0;
+    list-style: none; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .ingredients-list > li {
+      list-style: none;
+      margin: 0 0 13px;
+      position: relative;
+      line-height: 1.6; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .ingredients-list > li.ingredient-item-group {
+        cursor: initial; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .ingredients-list > li:last-child {
+        border-bottom: none; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .ingredients-list > li::after {
+        content: '';
+        clear: both;
+        display: table; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .ingredients-list > li .tick-circle {
+        content: '';
+        float: left;
+        width: 18px;
+        height: 18px;
+        margin: 6px 10px 0 0;
+        border-radius: 50%;
+        border: 2px solid #d0d0d0;
+        cursor: pointer;
+        position: relative; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .ingredients-list > li.ticked .ingredient-item-name.is-strikethrough-active {
+        text-decoration: line-through; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .ingredients-list > li.ticked .tick-circle {
+        border: 2px solid #9AD093 !important;
+        background: #9AD093;
+        -webkit-box-shadow: inset 0px 0px 0px 2px #fff;
+                box-shadow: inset 0px 0px 0px 2px #fff; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .directions-list {
+    counter-reset: count;
+    line-height: normal;
+    list-style: none;
+    margin: 0;
+    padding: 0; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .directions-list > li {
+      position: relative;
+      line-height: 1.8;
+      list-style: none;
+      padding-left: 40px;
+      margin: 0 0 16px; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .directions-list > li.direction-step-group {
+        min-height: 0;
+        font-size: 18px; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .directions-list > li::before {
+        counter-increment: count;
+        content: counter(count);
+        display: block;
+        position: absolute;
+        top: 0;
+        left: 0;
+        font-size: 24px;
+        font-weight: bold;
+        text-transform: uppercase;
+        line-height: 1.4;
+        color: #222222;
+        background: none;
+        width: 35px;
+        vertical-align: middle;
+        padding: 0;
+        margin-right: 20px; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .directions-list > li:last-child {
+        margin: 0; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .directions-list > li .direction-step-text {
+        margin-bottom: 20px;
+        font-size: 14px; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .directions-list > li .direction-step-text img {
+          max-width: 100%;
+          height: auto;
+          display: block; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .directions-list > li:last-child .direction-step-text {
+        margin-bottom: 0; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .direction-step img {
+    margin: 10px 0;
+    max-width: 100%;
+    height: auto;
+    display: block; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-notes {
+    margin-top: 30px;
+    padding-top: 20px;
+    border-top: 1px dashed rgba(0, 0, 0, 0.1);
+    margin-bottom: 30px; }
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-notes .recipe-card-notes-list,
+    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-notes ul {
+      margin: 0;
+      padding: 0;
+      list-style: none; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-notes .recipe-card-notes-list > li:empty,
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-notes ul > li:empty {
+        display: none; }
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-notes .recipe-card-notes-list > li,
+      .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-notes ul > li {
+        position: relative;
+        background-color: #FFF3E0;
+        color: #736458;
+        margin: 0 0 15px;
+        padding: 20px 25px 20px 50px;
+        list-style-type: none;
+        font-size: 14px;
+        border-radius: 5px; }
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-notes .recipe-card-notes-list > li::before,
+        .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-notes ul > li::before {
+          content: "i";
+          position: absolute;
+          display: block;
+          color: #fff;
+          background-color: #222222;
+          border-radius: 8px;
+          width: 16px;
+          height: 16px;
+          line-height: 16px;
+          font-size: 12px;
+          text-align: center;
+          left: 14px;
+          top: 50%;
+          -webkit-transform: translateY(-50%);
+              -ms-transform: translateY(-50%);
+                  transform: translateY(-50%); }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.recipe-card-noimage .recipe-card-image-preview,
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.recipe-card-noimage .recipe-card-image {
+    display: none; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.recipe-card-noimage .recipe-card-along-image {
+    float: none;
+    width: 100%; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.recipe-card-noimage .recipe-card-heading,
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple.recipe-card-noimage .recipe-card-details {
+    margin-left: 0; }
+
+@media screen and (max-width: 768px) {
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-image {
+    margin-bottom: 15px;
+    float: none;
+    width: 100%; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-along-image {
+    float: none;
+    width: 100%; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-heading,
+  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-details {
+    margin-left: 0; } }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * Colors
+ */
+/**
+ * Colors
+ */
+/**
+ * @style: Default
+*/
+/**
+ * @style: Newdesign
+*/
+/**
+ * @style: Simple
+*/
+/**
+ * Colors
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Grid System.
+ * https://make.wordpress.org/design/2019/10/31/proposal-a-consistent-spacing-system-for-wordpress/
+ */
+/**
+ * Dimensions.
+ */
+/**
+ * Shadows.
+ */
+/**
+ * Editor widths.
+ */
+/**
+ * Block UI.
+ */
+/**
+ * Border radii.
+ */
+/**
+ * Breakpoint mixins
+ */
+/**
+ * Long content fade mixin
+ *
+ * Creates a fading overlay to signify that the content is longer
+ * than the space allows.
+ */
+/**
+ * Focus styles.
+ */
+/**
+ * Applies editor left position to the selector passed as argument
+ */
+/**
+ * Styles that are reused verbatim in a few places
+ */
+/**
+ * Allows users to opt-out of animations via OS-level preferences.
+ */
+/**
+ * Reset default styles for JavaScript UI based pages.
+ * This is a WP-admin agnostic reset
+ */
+/**
+ * Reset the WP Admin page styles for Gutenberg-like pages.
+ */
+:root {
+  --wp-admin-theme-color: #007cba;
+  --wp-admin-theme-color-darker-10: #006ba1;
+  --wp-admin-theme-color-darker-20: #005a87; }
+
+/**
+ * Breakpoints & Media Queries
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Border radius.
+ */
+/**
+ * #.# Mixins SCSS
+ *
+ * Mixins allow you to define styles that can be re-used throughout your stylesheet.
+*/
+html[amp] *, html[amp] *:before, html[amp] *:after {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link {
+  display: none; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit {
+  right: 20px; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit {
+  margin-right: 0; }
+
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+#wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  line-height: 1.6;
+  font-size: 14px;
+  border: 1px solid #000;
+  border-radius: 0;
+  padding: 10px;
+  margin: 0 0 2em;
+  color: #222; }
+  #wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition h2 {
+    font-size: 2.4em;
+    line-height: 1;
+    letter-spacing: 0;
+    font-weight: 800;
+    padding: 0 0 .4em;
+    margin: 0;
+    border-bottom: 1px solid #000;
+    color: inherit; }
+  #wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition p {
+    margin: 0;
+    padding: 0;
+    font-size: 1em;
+    line-height: 1.4em; }
+  #wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition ul {
+    list-style: none !important;
+    margin: 0;
+    padding: 0; }
+    #wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition ul li {
+      position: relative;
+      margin: 0;
+      padding: 0;
+      border-top: 1px solid #000;
+      list-style-type: none; }
+      #wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition ul li.nutrition-facts-no-border, #wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition ul li:empty, #wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition ul li:first-child {
+        border: none; }
+      #wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition ul li::after {
+        content: '';
+        clear: both;
+        display: table; }
+    #wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition ul ul {
+      padding-left: 0; }
+      #wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition ul ul li {
+        padding-left: 20px; }
+  #wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition strong {
+    font-weight: 700; }
+    #wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition strong.nutrition-facts-label {
+      font-weight: 400; }
+  #wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-heading {
+    font-size: 14px;
+    font-weight: 800; }
+  #wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-right {
+    float: right; }
+  #wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-serving {
+    font-size: 1em; }
+  #wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-serving-size {
+    font-size: 1.1em;
+    font-weight: 800; }
+    #wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-serving-size + .nutrition-facts-label {
+      font-size: 1.1em;
+      font-weight: 800; }
+  #wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-hr {
+    border: none;
+    border-top: 1em solid;
+    margin: .2em 0 0;
+    padding: 0;
+    border-color: #000; }
+  #wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-spacer {
+    border: none;
+    height: .5em;
+    padding: 0;
+    background: #222; }
+  #wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-amount-per-serving {
+    display: block; }
+  #wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-calories {
+    font-weight: 800;
+    font-size: 1.8em; }
+    #wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-calories + .nutrition-facts-label {
+      float: right;
+      font-size: 2.5em;
+      line-height: 1em;
+      font-weight: 800; }
+  #wpzoom-recipe-nutrition .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-daily-value-text {
+    line-height: 1.2em;
+    font-size: .75em;
+    padding-top: 5px;
+    border-top: 4px solid #000; }
+
+#wpzoom-recipe-nutrition.layout-orientation-vertical .wp-block-wpzoom-recipe-card-block-nutrition {
+  display: inline-block; }
+  #wpzoom-recipe-nutrition.layout-orientation-vertical .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-daily-value-text {
+    max-width: 300px; }
+
+#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition::after {
+  content: '';
+  clear: both;
+  display: table; }
+
+#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-1,
+#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-2,
+#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-3 {
+  float: left;
+  width: 33.3333%;
+  padding-right: 10px; }
+
+#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-3 {
+  padding-right: 0; }
+
+#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-1 .nutrition-facts-hr {
+  border-top: 1px solid #aaa;
+  margin: .5em 0;
+  background-color: transparent; }
+  #wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-1 .nutrition-facts-hr + p {
+    line-height: 2em; }
+
+#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-1 .nutrition-facts-calories {
+  display: inline-block;
+  margin-top: .3em; }
+
+#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition ul > li.nutrition-facts-no-border:first-child {
+  line-height: 1em; }
+  #wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition ul > li.nutrition-facts-no-border:first-child > strong {
+    font-size: .75em; }
+
+#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-amount-per-serving {
+  display: inline-block; }
+
+#wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-bottom {
+  clear: both;
+  border-bottom: 1px solid #aaa;
+  padding-top: 5px; }
+  #wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-bottom li {
+    border: none;
+    display: inline-block;
+    padding: 0; }
+    #wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-bottom li .nutrition-facts-right {
+      float: none; }
+    #wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-bottom li > strong {
+      display: inline-block;
+      vertical-align: middle; }
+    #wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-bottom li::after {
+      content: '\2022';
+      display: inline-block;
+      vertical-align: middle;
+      margin: auto 10px; }
+    #wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .nutrition-facts-bottom li:last-child::after {
+      display: none; }
+
+@media screen and (max-width: 600px) {
+  #wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-1,
+  #wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-2,
+  #wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-3 {
+    float: none;
+    width: 100%;
+    padding-right: 0; }
+  #wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-1 p {
+    line-height: 1.8em; }
+  #wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-1 .nutrition-facts-hr {
+    border: none;
+    border-top: 1em solid;
+    margin: .2em 0 0;
+    padding: 0; }
+  #wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-2 > ul > .nutrition-facts-spacer {
+    display: none; }
+  #wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-3 > ul > li:nth-child(1),
+  #wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-3 > ul > li:nth-child(2) {
+    display: none; }
+  #wpzoom-recipe-nutrition.layout-orientation-horizontal .wp-block-wpzoom-recipe-card-block-nutrition .horizontal-column-3 > ul > li:nth-child(3) {
+    border-top: 1px solid #aaa; } }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * Colors
+ */
+/**
+ * Colors
+ */
+/**
+ * @style: Default
+*/
+/**
+ * @style: Newdesign
+*/
+/**
+ * @style: Simple
+*/
+/**
+ * Colors
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Grid System.
+ * https://make.wordpress.org/design/2019/10/31/proposal-a-consistent-spacing-system-for-wordpress/
+ */
+/**
+ * Dimensions.
+ */
+/**
+ * Shadows.
+ */
+/**
+ * Editor widths.
+ */
+/**
+ * Block UI.
+ */
+/**
+ * Border radii.
+ */
+/**
+ * Breakpoint mixins
+ */
+/**
+ * Long content fade mixin
+ *
+ * Creates a fading overlay to signify that the content is longer
+ * than the space allows.
+ */
+/**
+ * Focus styles.
+ */
+/**
+ * Applies editor left position to the selector passed as argument
+ */
+/**
+ * Styles that are reused verbatim in a few places
+ */
+/**
+ * Allows users to opt-out of animations via OS-level preferences.
+ */
+/**
+ * Reset default styles for JavaScript UI based pages.
+ * This is a WP-admin agnostic reset
+ */
+/**
+ * Reset the WP Admin page styles for Gutenberg-like pages.
+ */
+:root {
+  --wp-admin-theme-color: #007cba;
+  --wp-admin-theme-color-darker-10: #006ba1;
+  --wp-admin-theme-color-darker-20: #005a87; }
+
+/**
+ * Breakpoints & Media Queries
+ */
+/**
+ * Fonts & basic variables.
+ */
+/**
+ * Border radius.
+ */
+/**
+ * #.# Mixins SCSS
+ *
+ * Mixins allow you to define styles that can be re-used throughout your stylesheet.
+*/
+html[amp] *, html[amp] *:before, html[amp] *:after {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-print-link,
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-print-link {
+  display: none; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-image .wpzoom-recipe-card-pinit {
+  right: 20px; }
+
+html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pinit {
+  margin-right: 0; }
+
+.wpzoom-custom-recipe-card-post > .wpzoom-recipe-card-buttons {
+  display: none !important; }

--- a/dist/blocks.style.build.css
+++ b/dist/blocks.style.build.css
@@ -129,7 +129,6 @@ html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pin
     font-size: 22px;
     font-weight: 600;
     color: inherit;
-    margin: 0 0 20px;
     padding: 0;
     background-color: transparent;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
@@ -369,7 +368,6 @@ html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pin
     font-size: 22px;
     font-weight: 600;
     color: inherit;
-    margin: 0 0 20px;
     padding: 0;
     background-color: transparent;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
@@ -556,7 +554,6 @@ html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pin
     font-size: 22px;
     font-weight: 600;
     color: inherit;
-    margin: 0 0 20px;
     padding: 0;
     background-color: transparent;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
@@ -1244,7 +1241,11 @@ html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pin
       justify-content: space-between;
   -ms-flex-align: center;
       align-items: center;
-  margin-bottom: 20px; }
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+  margin-bottom: 25px; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-directions .directions-header .directions-title {
+    margin: 0; }
 
 .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-directions .image-switcher-container .toggle-input {
   display: none; }
@@ -1519,7 +1520,6 @@ html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pin
     font-size: 22px;
     font-weight: 600;
     color: #222222;
-    margin: 0 0 20px;
     padding: 0;
     background-color: transparent;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
@@ -1527,7 +1527,6 @@ html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pin
     font-size: 22px;
     font-weight: 600;
     color: #222222;
-    margin: 0 0 20px;
     padding: 0;
     background-color: transparent;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
@@ -1535,7 +1534,6 @@ html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pin
     font-size: 22px;
     font-weight: 600;
     color: #222222;
-    margin: 0 0 20px;
     padding: 0;
     background-color: transparent;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
@@ -1543,7 +1541,6 @@ html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pin
     font-size: 22px;
     font-weight: 600;
     color: #222222;
-    margin: 0 0 20px;
     padding: 0;
     background-color: transparent;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
@@ -1896,7 +1893,6 @@ html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pin
     font-size: 22px;
     font-weight: 600;
     color: #222222;
-    margin: 0 0 20px;
     padding: 0;
     background-color: transparent;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
@@ -1904,7 +1900,6 @@ html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pin
     font-size: 22px;
     font-weight: 600;
     color: #222222;
-    margin: 0 0 20px;
     padding: 0;
     background-color: transparent;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
@@ -1912,7 +1907,6 @@ html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pin
     font-size: 22px;
     font-weight: 600;
     color: #222222;
-    margin: 0 0 20px;
     padding: 0;
     background-color: transparent;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
@@ -1920,7 +1914,6 @@ html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pin
     font-size: 22px;
     font-weight: 600;
     color: #222222;
-    margin: 0 0 20px;
     padding: 0;
     background-color: transparent;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
@@ -2290,7 +2283,6 @@ html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pin
     font-size: 22px;
     font-weight: 600;
     color: #222222;
-    margin: 0 0 20px;
     padding: 0;
     background-color: transparent;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
@@ -2298,7 +2290,6 @@ html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pin
     font-size: 22px;
     font-weight: 600;
     color: #222222;
-    margin: 0 0 20px;
     padding: 0;
     background-color: transparent;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
@@ -2306,7 +2297,6 @@ html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pin
     font-size: 22px;
     font-weight: 600;
     color: #222222;
-    margin: 0 0 20px;
     padding: 0;
     background-color: transparent;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
@@ -2314,7 +2304,6 @@ html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pin
     font-size: 22px;
     font-weight: 600;
     color: #222222;
-    margin: 0 0 20px;
     padding: 0;
     background-color: transparent;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }

--- a/dist/blocks.style.build.css
+++ b/dist/blocks.style.build.css
@@ -1237,6 +1237,84 @@ html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pin
   .wpzoom-recipe-snippet-button.wp-block-wpzoom-recipe-card-block-print-recipe, .wpzoom-recipe-snippet-button.wp-block-wpzoom-recipe-card-block-jump-to-recipe, .wpzoom-recipe-card-buttons a.wpzoom-recipe-snippet-button {
     padding: 10px; } }
 
+.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-directions .directions-header {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-pack: justify;
+      justify-content: space-between;
+  -ms-flex-align: center;
+      align-items: center;
+  margin-bottom: 20px; }
+
+.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-directions .image-switcher-container .toggle-input {
+  display: none; }
+
+.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-directions .image-switcher-container .toggle-switch {
+  position: relative;
+  width: 54px;
+  height: 28px;
+  background-color: #e2e8f0;
+  border-radius: 30px;
+  cursor: pointer;
+  -webkit-transition: all 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+  -o-transition: all 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+  transition: all 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-align: center;
+      align-items: center; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-directions .image-switcher-container .toggle-switch::after {
+    content: "";
+    position: absolute;
+    z-index: 2;
+    width: 22px;
+    height: 22px;
+    background-color: white;
+    border-radius: 50%;
+    left: 3px;
+    -webkit-transition: all 0.3s ease;
+    -o-transition: all 0.3s ease;
+    transition: all 0.3s ease;
+    -webkit-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2); }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-directions .image-switcher-container .toggle-switch svg {
+    position: absolute;
+    z-index: 1;
+    -webkit-transition: all 0.3s ease;
+    -o-transition: all 0.3s ease;
+    transition: all 0.3s ease;
+    stroke: #64748b; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-directions .image-switcher-container .toggle-switch .icon-camera {
+    left: 8px;
+    opacity: 0;
+    -webkit-transform: scale(0.5);
+        -ms-transform: scale(0.5);
+            transform: scale(0.5); }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-directions .image-switcher-container .toggle-switch .icon-camera-off {
+    right: 8px;
+    opacity: 1; }
+
+.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-directions .image-switcher-container .toggle-input:checked + .toggle-label .toggle-switch {
+  background-color: #f43f5e; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-directions .image-switcher-container .toggle-input:checked + .toggle-label .toggle-switch::after {
+    -webkit-transform: translateX(26px);
+        -ms-transform: translateX(26px);
+            transform: translateX(26px); }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-directions .image-switcher-container .toggle-input:checked + .toggle-label .toggle-switch .icon-camera {
+    opacity: 1;
+    -webkit-transform: scale(1);
+        -ms-transform: scale(1);
+            transform: scale(1);
+    stroke: white; }
+  .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-directions .image-switcher-container .toggle-input:checked + .toggle-label .toggle-switch .icon-camera-off {
+    opacity: 0;
+    -webkit-transform: scale(0.5);
+        -ms-transform: scale(0.5);
+            transform: scale(0.5); }
+
+.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-directions:has(#direction-images-toggle-checkbox:not(:checked)) .directions-list img {
+  display: none !important; }
+
 .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default {
   padding: 20px 25px 30px;
   margin-top: 50px;
@@ -1469,81 +1547,6 @@ html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pin
     padding: 0;
     background-color: transparent;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
-  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .directions-title {
-    margin-bottom: 25px; }
-  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions .directions-header {
-    display: -ms-flexbox;
-    display: flex;
-    -ms-flex-pack: justify;
-        justify-content: space-between;
-    -ms-flex-align: center;
-        align-items: center;
-    margin-bottom: 20px; }
-  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions .image-switcher-container .toggle-input {
-    display: none; }
-  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions .image-switcher-container .toggle-switch {
-    position: relative;
-    width: 54px;
-    height: 28px;
-    background-color: #e2e8f0;
-    border-radius: 30px;
-    cursor: pointer;
-    -webkit-transition: all 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
-    -o-transition: all 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
-    transition: all 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
-    display: -ms-flexbox;
-    display: flex;
-    -ms-flex-align: center;
-        align-items: center; }
-    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions .image-switcher-container .toggle-switch::after {
-      content: "";
-      position: absolute;
-      z-index: 2;
-      width: 22px;
-      height: 22px;
-      background-color: white;
-      border-radius: 50%;
-      left: 3px;
-      -webkit-transition: all 0.3s ease;
-      -o-transition: all 0.3s ease;
-      transition: all 0.3s ease;
-      -webkit-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-              box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2); }
-    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions .image-switcher-container .toggle-switch svg {
-      position: absolute;
-      z-index: 1;
-      -webkit-transition: all 0.3s ease;
-      -o-transition: all 0.3s ease;
-      transition: all 0.3s ease;
-      stroke: #64748b; }
-    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions .image-switcher-container .toggle-switch .icon-camera {
-      left: 8px;
-      opacity: 0;
-      -webkit-transform: scale(0.5);
-          -ms-transform: scale(0.5);
-              transform: scale(0.5); }
-    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions .image-switcher-container .toggle-switch .icon-camera-off {
-      right: 8px;
-      opacity: 1; }
-  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions .image-switcher-container .toggle-input:checked + .toggle-label .toggle-switch {
-    background-color: #f43f5e; }
-    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions .image-switcher-container .toggle-input:checked + .toggle-label .toggle-switch::after {
-      -webkit-transform: translateX(26px);
-          -ms-transform: translateX(26px);
-              transform: translateX(26px); }
-    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions .image-switcher-container .toggle-input:checked + .toggle-label .toggle-switch .icon-camera {
-      opacity: 1;
-      -webkit-transform: scale(1);
-          -ms-transform: scale(1);
-              transform: scale(1);
-      stroke: white; }
-    .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions .image-switcher-container .toggle-input:checked + .toggle-label .toggle-switch .icon-camera-off {
-      opacity: 0;
-      -webkit-transform: scale(0.5);
-          -ms-transform: scale(0.5);
-              transform: scale(0.5); }
-  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-directions:has(#direction-images-toggle-checkbox:not(:checked)) .directions-list img {
-    display: none !important; }
   .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-default .recipe-card-ingredients {
     position: relative;
     color: #736458;
@@ -2315,8 +2318,6 @@ html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pin
     padding: 0;
     background-color: transparent;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
-  .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .directions-title {
-    margin-bottom: 25px; }
   .wp-block-wpzoom-recipe-card-block-recipe-card.is-style-simple .recipe-card-ingredients {
     position: relative;
     margin: 0 0 30px;

--- a/dist/blocks.style.build.css
+++ b/dist/blocks.style.build.css
@@ -1247,6 +1247,9 @@ html[amp] .wp-block-wpzoom-recipe-card-block-recipe-card .wpzoom-recipe-card-pin
   .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-directions .directions-header .directions-title {
     margin: 0; }
 
+.wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-directions .image-switcher-container p:empty {
+  display: none; }
+
 .wp-block-wpzoom-recipe-card-block-recipe-card .recipe-card-directions .image-switcher-container .toggle-input {
   display: none; }
 

--- a/src/__mixins.scss
+++ b/src/__mixins.scss
@@ -81,7 +81,6 @@
             font-size: 22px;
             font-weight: 600;
             color: $color;
-            @include margin( 0 0 20px );
             padding: 0;
             background-color: transparent;
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";

--- a/src/classes/class-wpzoom-print-template-manager.php
+++ b/src/classes/class-wpzoom-print-template-manager.php
@@ -229,6 +229,7 @@ if ( ! class_exists( 'WPZOOM_Print_Template_Manager' ) ) {
 			$details_content     = WPZOOM_Recipe_Card_Block::get_details_content( $details );
 			$ingredients_content = WPZOOM_Recipe_Card_Block::get_ingredients_content( $ingredients );
 			$steps_content       = WPZOOM_Recipe_Card_Block::get_steps_content( $steps );
+			$steps_content       = WPZOOM_Recipe_Card_Block::get_steps_content( $steps, false );
 
 			$strip_tags_notes = isset( $notes ) ? strip_tags( $notes ) : '';
 			$notes            = isset( $notes ) ? WPZOOM_Helpers::deserialize_block_attributes( $notes ) : '';

--- a/src/classes/class-wpzoom-settings.php
+++ b/src/classes/class-wpzoom-settings.php
@@ -622,6 +622,19 @@ class WPZOOM_Settings {
 								),
 							),
 							array(
+								'id'    => 'wpzoom_rcb_settings_hide_image_toggle',
+								'title' => __( 'Hide Image Toggle', 'recipe-card-blocks-by-wpzoom' ),
+								'type'  => 'checkbox',
+								'args'  => array(
+									'label_for'   => 'wpzoom_rcb_settings_hide_image_toggle',
+									'class'       => 'wpzoom-rcb-field',
+									'description' => esc_html__( 'Show/hide images switcher on Directions section', 'recipe-card-blocks-by-wpzoom' ),
+									'default'     => false,
+									'preview'     => true,
+									'preview_pos' => 'bottom',
+								),
+							),
+							array(
 								'id'    => 'wpzoom_rcb_settings_display_author',
 								'title' => __( 'Display Author', 'recipe-card-blocks-by-wpzoom' ),
 								'type'  => 'checkbox',

--- a/src/structured-data-blocks/class-wpzoom-recipe-card-block.php
+++ b/src/structured-data-blocks/class-wpzoom-recipe-card-block.php
@@ -195,6 +195,7 @@ class WPZOOM_Recipe_Card_Block {
 						'print_btn'          => WPZOOM_Settings::get( 'wpzoom_rcb_settings_display_print' ) === '1',
 						'pin_btn'            => WPZOOM_Settings::get( 'wpzoom_rcb_settings_display_pin' ) === '1',
 						'custom_author_name' => WPZOOM_Settings::get( 'wpzoom_rcb_settings_author_custom_name' ),
+						'hideImageToggle' 	 => WPZOOM_Settings::get( 'wpzoom_rcb_settings_hide_image_toggle' ) === '1',
 						'displayCourse'      => WPZOOM_Settings::get( 'wpzoom_rcb_settings_display_course' ) === '1',
 						'displayCuisine'     => WPZOOM_Settings::get( 'wpzoom_rcb_settings_display_cuisine' ) === '1',
 						'displayDifficulty'  => WPZOOM_Settings::get( 'wpzoom_rcb_settings_display_difficulty' ) === '1',
@@ -1307,9 +1308,35 @@ class WPZOOM_Recipe_Card_Block {
 
 		$listClassNames = implode( ' ', array( 'directions-list' ) );
 
-		return sprintf(
-			'<div class="recipe-card-directions"><h3 class="directions-title">%s</h3><ul class="%s">%s</ul></div>',
+		// Check if the toggle feature is enabled in settings
+		$show_toggle = isset(self::$settings['hideImageToggle']) && self::$settings['hideImageToggle'] === true;
+
+		$switcher_html = '';
+		if ( $show_toggle ) {
+			$switcher_html = '
+				<div class="image-switcher-container">
+					<input type="checkbox" id="direction-images-toggle-checkbox" checked class="toggle-input">
+					<label for="direction-images-toggle-checkbox" class="toggle-label">
+						<div class="toggle-switch">
+							<svg class="icon-camera" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z"/><circle cx="12" cy="13" r="3"/></svg>
+							<svg class="icon-camera-off" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><line x1="1" y1="1" x2="23" y2="23"/><path d="M21 21H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h3m3-3h6l2 3h4a2 2 0 0 1 2 2v9.34m-7.72-2.06a4 4 0 1 1-5.56-5.56"/></svg>
+						</div>
+					</label>
+				</div>';
+		}
+
+		$header_html = sprintf(
+			'<div class="directions-header">
+				<h3 class="directions-title">%s</h3>
+				%s
+			</div>',
 			self::$attributes['directionsTitle'],
+			$switcher_html
+		);
+
+		return sprintf(
+			'<div class="recipe-card-directions">%s <ul class="%s">%s</ul></div>',
+			$header_html,
 			esc_attr( $listClassNames ),
 			$direction_items
 		);

--- a/src/structured-data-blocks/class-wpzoom-recipe-card-block.php
+++ b/src/structured-data-blocks/class-wpzoom-recipe-card-block.php
@@ -1322,13 +1322,15 @@ class WPZOOM_Recipe_Card_Block {
 						</div>
 					</label>
 				</div>';
+				
+
+			$switcher_html = preg_replace('/\s+/', ' ', $switcher_html); // Collapse all whitespace to one space
+   			$switcher_html = str_replace('> <', '><', $switcher_html); // Remove spaces between tags
+    		$switcher_html = trim($switcher_html);
 		}
 
 		$header_html = sprintf(
-			'<div class="directions-header">
-				<h3 class="directions-title">%s</h3>
-				%s
-			</div>',
+			'<div class="directions-header"><h3 class="directions-title">%s</h3>%s</div>',
 			self::$attributes['directionsTitle'],
 			$switcher_html
 		);

--- a/src/structured-data-blocks/class-wpzoom-recipe-card-block.php
+++ b/src/structured-data-blocks/class-wpzoom-recipe-card-block.php
@@ -1303,13 +1303,12 @@ class WPZOOM_Recipe_Card_Block {
 		return force_balance_tags( $output );
 	}
 
-	public static function get_steps_content( array $steps ) {
+	public static function get_steps_content( array $steps , $showToggle = true) {
 		$direction_items = self::get_direction_items( $steps );
 
 		$listClassNames = implode( ' ', array( 'directions-list' ) );
 
-		// Check if the toggle feature is enabled in settings
-		$show_toggle = isset(self::$settings['hideImageToggle']) && self::$settings['hideImageToggle'] === true;
+		$show_toggle = isset(self::$settings['hideImageToggle']) && self::$settings['hideImageToggle'] === true && $showToggle;
 
 		$switcher_html = '';
 		if ( $show_toggle ) {

--- a/src/wpzoom-blocks/recipe-card/components/Direction.js
+++ b/src/wpzoom-blocks/recipe-card/components/Direction.js
@@ -31,7 +31,10 @@ class Direction extends Component {
     constructor( props ) {
         super( props );
 
-        this.state = { focus: '' };
+        this.state = { 
+            focus: '',  
+            hideImageToggleValue: true,
+        };
 
         this.changeStep = this.changeStep.bind( this );
         this.insertStep = this.insertStep.bind( this );
@@ -388,6 +391,15 @@ class Direction extends Component {
      */
     render() {
         const { attributes } = this.props;
+
+        const {
+            settings: {
+                0: {
+                    hideImageToggle
+                },
+            },
+        } = attributes;
+
         const { directionsTitle } = attributes;
 
         const classNames     = [ 'recipe-card-directions' ].filter( ( item ) => item ).join( ' ' );
@@ -397,17 +409,68 @@ class Direction extends Component {
 
         return (
             <div className={ classNames }>
-                <RichText
-                    tagName="h3"
-                    className="directions-title"
-                    format="string"
-                    value={ newDirectionsTitle }
-                    unstableOnFocus={ this.setFocusToTitle }
-                    onChange={ this.onChangeTitle }
-                    unstableOnSetup={ this.setTitleRef }
-                    placeholder={ __( 'Write Directions title', 'recipe-card-blocks-by-wpzoom' ) }
-                    keepPlaceholderOnFocus={ true }
-                />
+                <div class="directions-header">
+                    <RichText
+                        tagName="h3"
+                        className="directions-title"
+                        format="string"
+                        value={ newDirectionsTitle }
+                        unstableOnFocus={ this.setFocusToTitle }
+                        onChange={ this.onChangeTitle }
+                        unstableOnSetup={ this.setTitleRef }
+                        placeholder={ __( 'Write Directions title', 'recipe-card-blocks-by-wpzoom' ) }
+                        keepPlaceholderOnFocus={ true }
+                    />
+
+					{hideImageToggle && (
+						<div class="image-switcher-container">
+							<input
+								type="checkbox"
+								id="direction-images-toggle-checkbox"
+                                checked={this.state.hideImageToggleValue}
+								class="toggle-input"
+                                onChange={ () => this.setState({ hideImageToggleValue: !this.state.hideImageToggleValue }) }
+							/>
+							<label
+								for="direction-images-toggle-checkbox"
+								class="toggle-label"
+							>
+								<div class="toggle-switch">
+									<svg
+										class="icon-camera"
+										xmlns="http://www.w3.org/2000/svg"
+										width="16"
+										height="16"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="3"
+										stroke-linecap="round"
+										stroke-linejoin="round"
+									>
+										<path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z" />
+										<circle cx="12" cy="13" r="3" />
+									</svg>
+									<svg
+										class="icon-camera-off"
+										xmlns="http://www.w3.org/2000/svg"
+										width="14"
+										height="14"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="3"
+										stroke-linecap="round"
+										stroke-linejoin="round"
+									>
+										<line x1="1" y1="1" x2="23" y2="23" />
+										<path d="M21 21H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h3m3-3h6l2 3h4a2 2 0 0 1 2 2v9.34m-7.72-2.06a4 4 0 1 1-5.56-5.56" />
+									</svg>
+								</div>
+							</label>
+						</div>
+					)}
+                </div>
                 <ul className={ listClassNames }>{ this.getSteps() }</ul>
                 <div className="direction-buttons">{ this.getAddStepButton() }</div>
             </div>

--- a/src/wpzoom-blocks/recipe-card/components/Inspector.js
+++ b/src/wpzoom-blocks/recipe-card/components/Inspector.js
@@ -479,6 +479,7 @@ export default class Inspector extends Component {
                     print_btn,
                     pin_btn,
                     custom_author_name,
+                    hideImageToggle,
                     displayCourse,
                     displayCuisine,
                     displayDifficulty,
@@ -683,6 +684,16 @@ export default class Inspector extends Component {
                                 onChange={ authorName => this.onChangeSettings( authorName, 'custom_author_name' ) }
                             />
                         }
+                    </BaseControl>
+                    <BaseControl
+                        id={ `${ id }-direction-image-toggle` }
+                        label={ __( 'Hide images switcher', 'recipe-card-blocks-by-wpzoom' ) }
+                    >
+                        <ToggleControl
+                            label={ __( 'Show / Hide direction images', 'recipe-card-blocks-by-wpzoom' ) }
+                            checked={ hideImageToggle }
+                            onChange={ display => this.onChangeSettings( display, 'hideImageToggle' ) }
+                        />
                     </BaseControl>
                     {
                         style === 'newdesign' &&

--- a/src/wpzoom-blocks/recipe-card/skins/default.scss
+++ b/src/wpzoom-blocks/recipe-card/skins/default.scss
@@ -217,6 +217,94 @@
             margin-bottom: 25px;
         }
 
+        
+		.recipe-card-directions {
+			.directions-header {
+				display: flex;
+				justify-content: space-between;
+				align-items: center;
+				margin-bottom: 20px;
+			}
+
+			.image-switcher-container {
+				.toggle-input {
+					display: none;
+				}
+
+				.toggle-switch {
+					position: relative;
+					width: 54px; // Wider to fit icons
+					height: 28px;
+					background-color: #e2e8f0; // Soft gray
+					border-radius: 30px;
+					cursor: pointer;
+					transition: all 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+					display: flex;
+					align-items: center;
+
+					// The Moving Circle (Knob)
+					&::after {
+						content: "";
+						position: absolute;
+						z-index: 2;
+						width: 22px;
+						height: 22px;
+						background-color: white;
+						border-radius: 50%;
+						left: 3px;
+						transition: all 0.3s ease;
+						box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+					}
+
+					svg {
+						position: absolute;
+						z-index: 1;
+						transition: all 0.3s ease;
+						stroke: #64748b;
+					}
+
+					.icon-camera {
+                        left: 8px;
+                        opacity: 0; 
+                        transform: scale(0.5);
+					}
+                    
+					.icon-camera-off {
+                        right: 8px;
+                        opacity: 1;
+					}
+				}
+
+				// Checked State Logic
+				.toggle-input:checked + .toggle-label .toggle-switch {
+					background-color: #f43f5e; 
+
+					&::after {
+						transform: translateX(26px);
+					}
+
+					.icon-camera {
+                        opacity: 1;
+                        transform: scale(1);
+                        stroke: white;
+                    }
+                    
+					.icon-camera-off {
+                        opacity: 0;
+                        transform: scale(0.5);
+					}
+				}
+			}
+
+
+            &:has(#direction-images-toggle-checkbox:not(:checked)) {
+                .directions-list img {
+                    display: none !important;
+                }
+            }
+		}
+
+
         .recipe-card-ingredients {
             position: relative;
             color: $coffee;

--- a/src/wpzoom-blocks/recipe-card/skins/default.scss
+++ b/src/wpzoom-blocks/recipe-card/skins/default.scss
@@ -1,4 +1,87 @@
 .wp-block-wpzoom-recipe-card-block-recipe-card {
+    
+	.recipe-card-directions {
+		.directions-header {
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+			margin-bottom: 20px;
+		}
+
+		.image-switcher-container {
+			.toggle-input {
+				display: none;
+			}
+
+			.toggle-switch {
+				position: relative;
+				width: 54px;
+				height: 28px;
+				background-color: #e2e8f0;
+				border-radius: 30px;
+				cursor: pointer;
+				transition: all 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+				display: flex;
+				align-items: center;
+
+				&::after {
+					content: "";
+					position: absolute;
+					z-index: 2;
+					width: 22px;
+					height: 22px;
+					background-color: white;
+					border-radius: 50%;
+					left: 3px;
+					transition: all 0.3s ease;
+					box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+				}
+
+				svg {
+					position: absolute;
+					z-index: 1;
+					transition: all 0.3s ease;
+					stroke: #64748b;
+				}
+
+				.icon-camera {
+					left: 8px;
+					opacity: 0;
+					transform: scale(0.5);
+				}
+
+				.icon-camera-off {
+					right: 8px;
+					opacity: 1;
+				}
+			}
+
+			.toggle-input:checked + .toggle-label .toggle-switch {
+				background-color: #f43f5e;
+
+				&::after {
+					transform: translateX(26px);
+				}
+
+				.icon-camera {
+					opacity: 1;
+					transform: scale(1);
+					stroke: white;
+				}
+
+				.icon-camera-off {
+					opacity: 0;
+					transform: scale(0.5);
+				}
+			}
+		}
+
+		&:has(#direction-images-toggle-checkbox:not(:checked)) {
+			.directions-list img {
+				display: none !important;
+			}
+		}
+	}
 
     &.is-style-default {
         padding: 20px 25px 30px;
@@ -212,95 +295,6 @@
         $selectors: 'ingredients-title', 'directions-title', 'video-title', 'notes-title';
 
         @include recipe-sections-title( $default-heading-color, uppercase, $selectors... );
-
-        .directions-title {
-            margin-bottom: 25px;
-        }
-
-        
-		.recipe-card-directions {
-			.directions-header {
-				display: flex;
-				justify-content: space-between;
-				align-items: center;
-				margin-bottom: 20px;
-			}
-
-			.image-switcher-container {
-				.toggle-input {
-					display: none;
-				}
-
-				.toggle-switch {
-					position: relative;
-					width: 54px;
-					height: 28px;
-					background-color: #e2e8f0;
-					border-radius: 30px;
-					cursor: pointer;
-					transition: all 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
-					display: flex;
-					align-items: center;
-
-					&::after {
-						content: "";
-						position: absolute;
-						z-index: 2;
-						width: 22px;
-						height: 22px;
-						background-color: white;
-						border-radius: 50%;
-						left: 3px;
-						transition: all 0.3s ease;
-						box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-					}
-
-					svg {
-						position: absolute;
-						z-index: 1;
-						transition: all 0.3s ease;
-						stroke: #64748b;
-					}
-
-					.icon-camera {
-                        left: 8px;
-                        opacity: 0; 
-                        transform: scale(0.5);
-					}
-                    
-					.icon-camera-off {
-                        right: 8px;
-                        opacity: 1;
-					}
-				}
-
-				.toggle-input:checked + .toggle-label .toggle-switch {
-					background-color: #f43f5e; 
-
-					&::after {
-						transform: translateX(26px);
-					}
-
-					.icon-camera {
-                        opacity: 1;
-                        transform: scale(1);
-                        stroke: white;
-                    }
-                    
-					.icon-camera-off {
-                        opacity: 0;
-                        transform: scale(0.5);
-					}
-				}
-			}
-
-
-            &:has(#direction-images-toggle-checkbox:not(:checked)) {
-                .directions-list img {
-                    display: none !important;
-                }
-            }
-		}
 
 
         .recipe-card-ingredients {

--- a/src/wpzoom-blocks/recipe-card/skins/default.scss
+++ b/src/wpzoom-blocks/recipe-card/skins/default.scss
@@ -14,6 +14,11 @@
 		}
 
 		.image-switcher-container {
+
+            p:empty {
+                display: none;
+            }
+
 			.toggle-input {
 				display: none;
 			}
@@ -29,6 +34,7 @@
 				display: flex;
 				align-items: center;
 
+                
 				&::after {
 					content: "";
 					position: absolute;

--- a/src/wpzoom-blocks/recipe-card/skins/default.scss
+++ b/src/wpzoom-blocks/recipe-card/skins/default.scss
@@ -233,16 +233,15 @@
 
 				.toggle-switch {
 					position: relative;
-					width: 54px; // Wider to fit icons
+					width: 54px;
 					height: 28px;
-					background-color: #e2e8f0; // Soft gray
+					background-color: #e2e8f0;
 					border-radius: 30px;
 					cursor: pointer;
 					transition: all 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
 					display: flex;
 					align-items: center;
 
-					// The Moving Circle (Knob)
 					&::after {
 						content: "";
 						position: absolute;
@@ -275,7 +274,6 @@
 					}
 				}
 
-				// Checked State Logic
 				.toggle-input:checked + .toggle-label .toggle-switch {
 					background-color: #f43f5e; 
 

--- a/src/wpzoom-blocks/recipe-card/skins/default.scss
+++ b/src/wpzoom-blocks/recipe-card/skins/default.scss
@@ -1,11 +1,16 @@
 .wp-block-wpzoom-recipe-card-block-recipe-card {
-    
+
 	.recipe-card-directions {
 		.directions-header {
 			display: flex;
 			justify-content: space-between;
 			align-items: center;
-			margin-bottom: 20px;
+            flex-wrap: wrap;
+            margin-bottom: 25px;
+
+            .directions-title{
+                margin: 0;
+            }
 		}
 
 		.image-switcher-container {

--- a/src/wpzoom-blocks/recipe-card/skins/simple.scss
+++ b/src/wpzoom-blocks/recipe-card/skins/simple.scss
@@ -252,9 +252,6 @@
 
         @include recipe-sections-title( $simple-heading-color, uppercase, $selectors... );
 
-        .directions-title {
-            margin-bottom: 25px;
-        }
 
         .recipe-card-ingredients {
             position: relative;


### PR DESCRIPTION
This PR adds a user-facing toggle to the "Directions" section of the recipe card. This allows readers to hide images if they prefer a more compact, text-only view while cooking, or show them for visual guidance.

<img width="1251" height="877" alt="image" src="https://github.com/user-attachments/assets/4e88b519-16c2-4d2f-afc9-a79455f3939b" />
